### PR TITLE
Group rework

### DIFF
--- a/libzmq/benches/curve.rs
+++ b/libzmq/benches/curve.rs
@@ -14,7 +14,6 @@ const MSG_SIZE: usize = 50;
 
 lazy_static! {
     static ref ADDR: TcpAddr = "127.0.0.1:*".try_into().unwrap();
-    static ref GROUP: &'static Group = "group".try_into().unwrap();
 }
 
 fn gen_dataset(dataset_size: usize, msg_size: usize) -> Vec<Vec<u8>> {

--- a/libzmq/benches/socket.rs
+++ b/libzmq/benches/socket.rs
@@ -14,7 +14,7 @@ const MSG_SIZE: usize = 50;
 
 lazy_static! {
     static ref ADDR: TcpAddr = "127.0.0.1:*".try_into().unwrap();
-    static ref GROUP: &'static Group = "group".try_into().unwrap();
+    static ref GROUP: Group = "group".try_into().unwrap();
 }
 
 fn gen_dataset(dataset_size: usize, msg_size: usize) -> Vec<Vec<u8>> {
@@ -70,7 +70,7 @@ pub(crate) fn bench(c: &mut Criterion) {
                 let dataset = gen_dataset(MSG_AMOUNT, MSG_SIZE);
                 for data in dataset {
                     let mut data: Msg = data.into();
-                    data.set_group(*GROUP);
+                    data.set_group(&*GROUP);
 
                     producer.send(data).unwrap();
                     let _ = consumer.try_recv(&mut msg);

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -40,32 +40,32 @@ use std::sync::Arc;
 ///     .build()?;
 ///
 /// let bound = radio.last_endpoint().unwrap();
-/// let a: &Group = "A".try_into()?;
-/// let b: &Group = "B".try_into()?;
+/// let a: Group = "A".try_into()?;
+/// let b: Group = "B".try_into()?;
 ///
 /// let dish_a = DishBuilder::new()
 ///     .connect(&bound)
-///     .join(a)
+///     .join(&a)
 ///     .build()?;
 ///
 /// let dish_b = DishBuilder::new()
 ///     .connect(bound)
-///     .join(b)
+///     .join(&b)
 ///     .build()?;
 ///
 /// // Start the feed. It has no conceptual start nor end, thus we
 /// // don't synchronize with the subscribers.
 /// thread::spawn(move || {
-///     let a: &Group = "A".try_into().unwrap();
-///     let b: &Group = "B".try_into().unwrap();
+///     let a: Group = "A".try_into().unwrap();
+///     let b: Group = "B".try_into().unwrap();
 ///     let mut count = 0;
 ///     loop {
 ///         let mut msg = Msg::new();
 ///         // Alternate between the two groups.
 ///         let group = if count % 2 == 0 {
-///             a
+///             &a
 ///         } else {
-///             b
+///             &b
 ///         };
 ///
 ///         msg.set_group(group);
@@ -78,10 +78,10 @@ use std::sync::Arc;
 ///
 /// // Each dish will only receive the messages from their respective groups.
 /// let msg = dish_a.recv_msg()?;
-/// assert_eq!(msg.group().unwrap(), a);
+/// assert_eq!(msg.group().unwrap(), &a);
 ///
 /// let msg = dish_b.recv_msg()?;
-/// assert_eq!(msg.group().unwrap(), b);
+/// assert_eq!(msg.group().unwrap(), &b);
 /// #
 /// #     Ok(())
 /// # }

--- a/libzmq/src/utils.rs
+++ b/libzmq/src/utils.rs
@@ -72,7 +72,7 @@ pub fn has(capability: &str) -> bool {
 ///
 /// let radio_addr: InprocAddr = "frontend".try_into()?;
 /// let dish_addr: InprocAddr = "backend".try_into()?;
-/// let group: &Group = "some group".try_into()?;
+/// let group: Group = "some group".try_into()?;
 ///
 /// let radio = RadioBuilder::new()
 ///     .bind(&radio_addr)
@@ -80,7 +80,7 @@ pub fn has(capability: &str) -> bool {
 ///
 /// let frontend = DishBuilder::new()
 ///     .connect(&radio_addr)
-///     .join(group)
+///     .join(&group)
 ///     .build()?;
 ///
 /// let backend = RadioBuilder::new()
@@ -89,13 +89,13 @@ pub fn has(capability: &str) -> bool {
 ///
 /// let dish = DishBuilder::new()
 ///     .connect(&dish_addr)
-///     .join(group)
+///     .join(&group)
 ///     .build()?;
 ///
 /// let proxy_handle = thread::spawn(move || proxy(frontend, backend));
 ///
 /// let mut msg = Msg::new();
-/// msg.set_group(group);
+/// msg.set_group(&group);
 /// radio.send(msg)?;
 ///
 /// let msg = dish.recv_msg()?;


### PR DESCRIPTION
* `Group` was renamed `GroupSlice` and uses a `CStr` underneat. I cannot be constructed directly.
* `GroupOwned` was renamed `Group` and use a `CString` underneat.
* Msg::group returns a `GroupSlice`.
* Msg::set_group takes a `GroupSlice` which removes the need to allocate a `CString`.

The general logic is that users are more likely to use a the owned version of the group than the slice version. Thus it makes sense that the slice version's name is more verbose. Furthermose, since `Msg::set_group` can be part of the hotpath, It is worthwhile to remove the extra `CString` allocation with each call.