### PR TITLE
Added SendMsg::{route, try_route} convenience method

### DIFF
--- a/libzmq/benches/bench_main.rs
+++ b/libzmq/benches/bench_main.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main};
 
 mod curve;
-mod socket;
 mod msg;
+mod socket;
 
 criterion_group!(benches, socket::bench, curve::bench, msg::bench);
 criterion_main!(benches);

--- a/libzmq/benches/curve.rs
+++ b/libzmq/benches/curve.rs
@@ -44,15 +44,14 @@ pub(crate) fn bench(c: &mut Criterion) {
 
             consumer.send("").unwrap();
             let mut msg = producer.recv_msg().unwrap();
-            let routing_id = msg.routing_id().unwrap();
+            let id = msg.routing_id().unwrap();
 
             b.iter(|| {
                 let dataset = gen_dataset(MSG_AMOUNT, MSG_SIZE);
                 for data in dataset {
-                    let mut data: Msg = data.into();
-                    data.set_routing_id(routing_id);
+                    let data: Msg = data.into();
 
-                    producer.send(data).unwrap();
+                    producer.route(data, id).unwrap();
                     let _ = consumer.try_recv(&mut msg);
                 }
             });
@@ -82,15 +81,14 @@ pub(crate) fn bench(c: &mut Criterion) {
 
             consumer.send("").unwrap();
             let mut msg = producer.recv_msg().unwrap();
-            let routing_id = msg.routing_id().unwrap();
+            let id = msg.routing_id().unwrap();
 
             b.iter(|| {
                 let dataset = gen_dataset(MSG_AMOUNT, MSG_SIZE);
                 for data in dataset {
-                    let mut data: Msg = data.into();
-                    data.set_routing_id(routing_id);
+                    let data: Msg = data.into();
 
-                    producer.send(data).unwrap();
+                    producer.route(data, id).unwrap();
                     let _ = consumer.try_recv(&mut msg);
                 }
             });

--- a/libzmq/benches/msg.rs
+++ b/libzmq/benches/msg.rs
@@ -40,6 +40,6 @@ pub(crate) fn bench(c: &mut Criterion) {
                 black_box(msg);
             });
         })
-        .measurement_time(Duration::from_secs(30))
+        .measurement_time(Duration::from_secs(30)),
     );
 }

--- a/libzmq/benches/socket.rs
+++ b/libzmq/benches/socket.rs
@@ -45,15 +45,14 @@ pub(crate) fn bench(c: &mut Criterion) {
 
             consumer.send("").unwrap();
             let mut msg = producer.recv_msg().unwrap();
-            let routing_id = msg.routing_id().unwrap();
+            let id = msg.routing_id().unwrap();
 
             b.iter(|| {
                 let dataset = gen_dataset(MSG_AMOUNT, MSG_SIZE);
                 for data in dataset {
-                    let mut data: Msg = data.into();
-                    data.set_routing_id(routing_id);
+                    let data: Msg = data.into();
 
-                    producer.send(data).unwrap();
+                    producer.route(data, id).unwrap();
                     let _ = consumer.try_recv(&mut msg);
                 }
             });

--- a/libzmq/examples/basic_req_rep.rs
+++ b/libzmq/examples/basic_req_rep.rs
@@ -15,10 +15,9 @@ fn main() -> Result<(), failure::Error> {
 
             // Retrieve the routing_id to route the reply to the client.
             let id = request.routing_id().unwrap();
-            let mut reply: Msg = "pong".into();
-            reply.set_routing_id(id);
+            let reply: Msg = "pong".into();
             // We cast the Error<Msg> to Error<()>. This drops the Msg.
-            server.send(reply).map_err(Error::cast)?;
+            server.route(reply, id).map_err(Error::cast)?;
         }
     });
 

--- a/libzmq/examples/reliable_req_rep.rs
+++ b/libzmq/examples/reliable_req_rep.rs
@@ -30,10 +30,9 @@ fn main() -> Result<(), failure::Error> {
 
             // Retrieve the routing_id to route the reply to the client.
             let id = request.routing_id().unwrap();
-            let mut reply: Msg = "pong".into();
-            reply.set_routing_id(id);
+            let reply: Msg = "pong".into();
 
-            if let Err(err) = server.send(reply) {
+            if let Err(err) = server.route(reply, id) {
                 match err.kind() {
                     // Cannot route msg, drop it.
                     WouldBlock | HostUnreachable => (),

--- a/libzmq/examples/secure_req_rep.rs
+++ b/libzmq/examples/secure_req_rep.rs
@@ -52,10 +52,9 @@ fn main() -> Result<(), failure::Error> {
 
             // Retrieve the routing_id to route the reply to the client.
             let id = request.routing_id().unwrap();
-            let mut reply: Msg = "pong".into();
-            reply.set_routing_id(id);
+            let reply: Msg = "pong".into();
 
-            if let Err(err) = server.send(reply) {
+            if let Err(err) = server.route(reply, id) {
                 match err.kind() {
                     // Cannot route msg, drop it.
                     WouldBlock | HostUnreachable => (),

--- a/libzmq/src/auth/server.rs
+++ b/libzmq/src/auth/server.rs
@@ -219,9 +219,8 @@ impl AuthServer {
                             let reply = self.on_request(request);
                             let ser = bincode::serialize(&reply).unwrap();
 
-                            let mut msg: Msg = ser.into();
-                            msg.set_routing_id(id);
-                            self.request.send(msg).map_err(Error::cast)?;
+                            let msg: Msg = ser.into();
+                            self.request.route(msg, id).map_err(Error::cast)?;
                         }
                         _ => unreachable!(),
                     }

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -10,9 +10,7 @@ use sys::errno;
 
 use bitflags::bitflags;
 
-use std::{
-    os::raw::{c_short, c_void},
-};
+use std::os::raw::{c_short, c_void};
 
 bitflags! {
     /// The event flags that can be specified to the poller.

--- a/libzmq/src/socket/client.rs
+++ b/libzmq/src/socket/client.rs
@@ -62,13 +62,11 @@ use std::sync::Arc;
 ///
 /// // Reply to the client.
 /// let mut reply: Msg = "it takes 224 bits to store a i32 in java".into();
-/// reply.set_routing_id(id);
-/// server.send(reply)?;
+/// server.route(reply, id)?;
 ///
 /// // We can reply twice if we want.
 /// let mut reply: Msg = "also don't talk to me".into();
-/// reply.set_routing_id(id);
-/// server.send(reply)?;
+/// server.route(reply, id)?;
 ///
 /// // Retreive the first reply.
 /// let mut msg = client.recv_msg()?;


### PR DESCRIPTION
This simultaneously sets the msg's routing id and sends it.