### PR TITLE
Updated examples to use `Server::route`

### DIFF
--- a/libzmq/examples/basic_req_rep.rs
+++ b/libzmq/examples/basic_req_rep.rs
@@ -15,9 +15,8 @@ fn main() -> Result<(), failure::Error> {
 
             // Retrieve the routing_id to route the reply to the client.
             let id = request.routing_id().unwrap();
-            let reply: Msg = "pong".into();
             // We cast the Error<Msg> to Error<()>. This drops the Msg.
-            server.route(reply, id).map_err(Error::cast)?;
+            server.route("pong", id).map_err(Error::cast)?;
         }
     });
 

--- a/libzmq/examples/reliable_req_rep.rs
+++ b/libzmq/examples/reliable_req_rep.rs
@@ -30,9 +30,7 @@ fn main() -> Result<(), failure::Error> {
 
             // Retrieve the routing_id to route the reply to the client.
             let id = request.routing_id().unwrap();
-            let reply: Msg = "pong".into();
-
-            if let Err(err) = server.route(reply, id) {
+            if let Err(err) = server.route("pong", id) {
                 match err.kind() {
                     // Cannot route msg, drop it.
                     WouldBlock | HostUnreachable => (),

--- a/libzmq/examples/secure_req_rep.rs
+++ b/libzmq/examples/secure_req_rep.rs
@@ -52,9 +52,7 @@ fn main() -> Result<(), failure::Error> {
 
             // Retrieve the routing_id to route the reply to the client.
             let id = request.routing_id().unwrap();
-            let reply: Msg = "pong".into();
-
-            if let Err(err) = server.route(reply, id) {
+            if let Err(err) = server.route("pong", id) {
                 match err.kind() {
                     // Cannot route msg, drop it.
                     WouldBlock | HostUnreachable => (),

--- a/libzmq/src/auth/server.rs
+++ b/libzmq/src/auth/server.rs
@@ -219,8 +219,7 @@ impl AuthServer {
                             let reply = self.on_request(request);
                             let ser = bincode::serialize(&reply).unwrap();
 
-                            let msg: Msg = ser.into();
-                            self.request.route(msg, id).map_err(Error::cast)?;
+                            self.request.route(ser, id).map_err(Error::cast)?;
                         }
                         _ => unreachable!(),
                     }

--- a/libzmq/src/msg.rs
+++ b/libzmq/src/msg.rs
@@ -44,12 +44,10 @@ use std::{
 /// // ØMQ generates a `RoutingId` for the client upon reception of the
 /// // first message.
 /// let msg = server.recv_msg()?;
-/// let routing_id = msg.routing_id().unwrap();
+/// let id = msg.routing_id().unwrap();
 ///
 /// // This `RoutingId` is used to route messages back to the `Client`.
-/// let mut msg: Msg = "".into();
-/// msg.set_routing_id(routing_id);
-/// server.send(msg)?;
+/// server.route("", id)?;
 /// #
 /// #     Ok(())
 /// # }

--- a/libzmq/src/socket/client.rs
+++ b/libzmq/src/socket/client.rs
@@ -61,12 +61,10 @@ use std::sync::Arc;
 /// let id = msg.routing_id().unwrap();
 ///
 /// // Reply to the client.
-/// let mut reply: Msg = "it takes 224 bits to store a i32 in java".into();
-/// server.route(reply, id)?;
+/// server.route("it takes 224 bits to store a i32 in java", id)?;
 ///
-/// // We can reply twice if we want.
-/// let mut reply: Msg = "also don't talk to me".into();
-/// server.route(reply, id)?;
+/// // We send as much replies as we want.
+/// server.route("also don't talk to me", id)?;
 ///
 /// // Retreive the first reply.
 /// let mut msg = client.recv_msg()?;

--- a/libzmq/src/socket/server.rs
+++ b/libzmq/src/socket/server.rs
@@ -60,10 +60,8 @@ use std::sync::Arc;
 ///
 /// // Using this `routing_id`, we can now route as many replies as we
 /// // want to the client.
-/// let msg: Msg = "reply 1".into();
-/// server.route(msg, id)?;
-/// let msg: Msg = "reply 2".into();
-/// server.route(msg, id)?;
+/// server.route("reply 1", id)?;
+/// server.route("reply 2", id)?;
 ///
 /// // The `routing_id` is discarted when the message is sent to the client.
 /// let mut msg = client.recv_msg()?;


### PR DESCRIPTION
Encourages the users to use the more ergonomic `Server::route` instead of setting the routing id then using send.