### PR TITLE
Add Poller support for fd

### DIFF
--- a/libzmq/src/core/raw.rs
+++ b/libzmq/src/core/raw.rs
@@ -61,22 +61,20 @@ fn connect(socket_ptr: *mut c_void, c_string: CString) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => {
-                    panic!("invalid endpoint : {}", c_string.to_string_lossy())
-                }
-                errno::EPROTONOSUPPORT => Error::new(ErrorKind::InvalidInput(
-                    "transport not supported",
-                )),
-                errno::ENOCOMPATPROTO => Error::new(ErrorKind::InvalidInput(
-                    "transport incompatible",
-                )),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EMTHREAD => panic!("no i/o thread available"),
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EINVAL => {
+                panic!("invalid endpoint : {}", c_string.to_string_lossy())
             }
+            errno::EPROTONOSUPPORT => {
+                Error::new(ErrorKind::InvalidInput("transport not supported"))
+            }
+            errno::ENOCOMPATPROTO => {
+                Error::new(ErrorKind::InvalidInput("transport incompatible"))
+            }
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EMTHREAD => panic!("no i/o thread available"),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -90,25 +88,23 @@ fn bind(socket_ptr: *mut c_void, c_string: CString) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => {
-                    panic!("invalid endpoint : {}", c_string.to_string_lossy())
-                }
-                errno::EPROTONOSUPPORT => Error::new(ErrorKind::InvalidInput(
-                    "transport not supported",
-                )),
-                errno::ENOCOMPATPROTO => Error::new(ErrorKind::InvalidInput(
-                    "transport incompatible",
-                )),
-                errno::EADDRINUSE => Error::new(ErrorKind::AddrInUse),
-                errno::EADDRNOTAVAIL => Error::new(ErrorKind::AddrNotAvailable),
-                errno::ENODEV => Error::new(ErrorKind::AddrNotAvailable),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EMTHREAD => panic!("no i/o thread available"),
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EINVAL => {
+                panic!("invalid endpoint : {}", c_string.to_string_lossy())
             }
+            errno::EPROTONOSUPPORT => {
+                Error::new(ErrorKind::InvalidInput("transport not supported"))
+            }
+            errno::ENOCOMPATPROTO => {
+                Error::new(ErrorKind::InvalidInput("transport incompatible"))
+            }
+            errno::EADDRINUSE => Error::new(ErrorKind::AddrInUse),
+            errno::EADDRNOTAVAIL => Error::new(ErrorKind::AddrNotAvailable),
+            errno::ENODEV => Error::new(ErrorKind::AddrNotAvailable),
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EMTHREAD => panic!("no i/o thread available"),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -122,18 +118,16 @@ fn disconnect(socket_ptr: *mut c_void, c_string: CString) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => {
-                    panic!("invalid endpoint : {}", c_string.to_string_lossy())
-                }
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::ENOENT => Error::new(ErrorKind::NotFound(
-                    "endpoint was not connected to",
-                )),
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EINVAL => {
+                panic!("invalid endpoint : {}", c_string.to_string_lossy())
             }
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::ENOENT => {
+                Error::new(ErrorKind::NotFound("endpoint was not connected to"))
+            }
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -147,18 +141,16 @@ fn unbind(socket_ptr: *mut c_void, c_string: CString) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => {
-                    panic!("invalid endpoint : {}", c_string.to_string_lossy())
-                }
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::ENOENT => {
-                    Error::new(ErrorKind::NotFound("endpoint was not bound to"))
-                }
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EINVAL => {
+                panic!("invalid endpoint : {}", c_string.to_string_lossy())
             }
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::ENOENT => {
+                Error::new(ErrorKind::NotFound("endpoint was not bound to"))
+            }
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)

--- a/libzmq/src/core/recv.rs
+++ b/libzmq/src/core/recv.rs
@@ -22,19 +22,17 @@ fn recv(
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
-                errno::ENOTSUP => panic!("recv not supported by socket type"),
-                errno::EFSM => panic!(
-                    "operation cannot be completed in current socket state"
-                ),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                errno::EFAULT => panic!("invalid message"),
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
+            errno::ENOTSUP => panic!("recv not supported by socket type"),
+            errno::EFSM => {
+                panic!("operation cannot be completed in current socket state")
             }
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            errno::EFAULT => panic!("invalid message"),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)

--- a/libzmq/src/core/send.rs
+++ b/libzmq/src/core/send.rs
@@ -22,33 +22,23 @@ fn send(
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EAGAIN => {
-                    Error::with_content(ErrorKind::WouldBlock, msg)
-                }
-                errno::ENOTSUP => {
-                    panic!("send is not supported by socket type")
-                }
-                errno::EINVAL => panic!(
-                    "multipart messages are not supported by socket type"
-                ),
-                errno::EFSM => panic!(
-                    "operation cannot be completed in current socket state"
-                ),
-                errno::ETERM => {
-                    Error::with_content(ErrorKind::CtxTerminated, msg)
-                }
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EINTR => {
-                    Error::with_content(ErrorKind::Interrupted, msg)
-                }
-                errno::EFAULT => panic!("invalid message"),
-                errno::EHOSTUNREACH => {
-                    Error::with_content(ErrorKind::HostUnreachable, msg)
-                }
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EAGAIN => Error::with_content(ErrorKind::WouldBlock, msg),
+            errno::ENOTSUP => panic!("send is not supported by socket type"),
+            errno::EINVAL => {
+                panic!("multipart messages are not supported by socket type")
             }
+            errno::EFSM => {
+                panic!("operation cannot be completed in current socket state")
+            }
+            errno::ETERM => Error::with_content(ErrorKind::CtxTerminated, msg),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EINTR => Error::with_content(ErrorKind::Interrupted, msg),
+            errno::EFAULT => panic!("invalid message"),
+            errno::EHOSTUNREACH => {
+                Error::with_content(ErrorKind::HostUnreachable, msg)
+            }
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)

--- a/libzmq/src/core/sockopt.rs
+++ b/libzmq/src/core/sockopt.rs
@@ -104,14 +104,12 @@ fn getsockopt(
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => panic!("invalid option"),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                _ => panic!(msg_from_errno(errno)),
-            }
+        let err = match errno {
+            errno::EINVAL => panic!("invalid option"),
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -233,14 +231,12 @@ fn setsockopt(
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => panic!("invalid option"),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                _ => panic!(msg_from_errno(errno)),
-            }
+        let err = match errno {
+            errno::EINVAL => panic!("invalid option"),
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)

--- a/libzmq/src/old.rs
+++ b/libzmq/src/old.rs
@@ -16,26 +16,18 @@ fn send(
     mut msg: Msg,
     more: bool,
 ) -> Result<(), Error> {
-    let flags = {
-        if more {
-            sys::ZMQ_SNDMORE
-        } else {
-            0
-        }
-    };
+    let flags = if more { sys::ZMQ_SNDMORE } else { 0 };
     let rc = unsafe {
         sys::zmq_msg_send(msg.as_mut_ptr(), mut_sock_ptr, flags as c_int)
     };
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
-                _ => panic!(msg_from_errno(errno)),
-            }
+        let err = match errno {
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -49,13 +41,11 @@ fn recv(mut_sock_ptr: *mut c_void, msg: &mut Msg) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
-                _ => panic!(msg_from_errno(errno)),
-            }
+        let err = match errno {
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)

--- a/libzmq/src/socket/dish.rs
+++ b/libzmq/src/socket/dish.rs
@@ -18,17 +18,15 @@ fn join(socket_mut_ptr: *mut c_void, group: &GroupSlice) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => Error::new(ErrorKind::InvalidInput(
-                    "cannot join group twice",
-                )),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EMTHREAD => panic!("no i/o thread available"),
-                _ => panic!(msg_from_errno(errno)),
+        let err = match errno {
+            errno::EINVAL => {
+                Error::new(ErrorKind::InvalidInput("cannot join group twice"))
             }
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EMTHREAD => panic!("no i/o thread available"),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -43,17 +41,15 @@ fn leave(socket_mut_ptr: *mut c_void, group: &GroupSlice) -> Result<(), Error> {
 
     if rc == -1 {
         let errno = unsafe { sys::zmq_errno() };
-        let err = {
-            match errno {
-                errno::EINVAL => Error::new(ErrorKind::InvalidInput(
-                    "cannot leave a group that wasn't joined",
-                )),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-                errno::EINTR => Error::new(ErrorKind::Interrupted),
-                errno::ENOTSOCK => panic!("invalid socket"),
-                errno::EMTHREAD => panic!("no i/o thread available"),
-                _ => panic!(msg_from_errno(errno)),
-            }
+        let err = match errno {
+            errno::EINVAL => Error::new(ErrorKind::InvalidInput(
+                "cannot leave a group that wasn't joined",
+            )),
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::EINTR => Error::new(ErrorKind::Interrupted),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::EMTHREAD => panic!("no i/o thread available"),
+            _ => panic!(msg_from_errno(errno)),
         };
 
         Err(err)
@@ -563,13 +559,7 @@ mod test {
             loop {
                 let mut msg = Msg::new();
                 // Alternate between the two groups.
-                let group = {
-                    if count % 2 == 0 {
-                        &a
-                    } else {
-                        &b
-                    }
-                };
+                let group = if count % 2 == 0 { &a } else { &b };
 
                 msg.set_group(group);
                 radio.send(msg).unwrap();

--- a/libzmq/src/utils.rs
+++ b/libzmq/src/utils.rs
@@ -120,11 +120,9 @@ where
     assert_eq!(rc, -1);
 
     let errno = unsafe { sys::zmq_errno() };
-    let err = {
-        match errno {
-            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
-            _ => panic!(msg_from_errno(errno)),
-        }
+    let err = match errno {
+        errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+        _ => panic!(msg_from_errno(errno)),
     };
 
     Err(err)


### PR DESCRIPTION
* Methods Poller::{Add, Remove, Modify> now takes an Into<Pollable>.
* From<T> for Pollable is implemented for all socket types and
    all types that implement AsRawFd.
* Renamed Poller::poll to Poller::try_poll.
* Renamed Poller::block to Poller::poll.
* Renamed Flags to Trigger.
* Removed the need to protect against spurious wakeups
    when iterating over events.
* Improved poll module documentation.