### PR TITLE
Account for the default high water mark while deserializing

### DIFF
--- a/libzmq/src/core/mod.rs
+++ b/libzmq/src/core/mod.rs
@@ -128,6 +128,12 @@ pub enum Quantity {
 
 pub use Quantity::*;
 
+impl Quantity {
+    pub(crate) fn default_high_water_mark() -> Self {
+        Quantity::Limited(1000)
+    }
+}
+
 impl Default for Quantity {
     fn default() -> Self {
         Unlimited

--- a/libzmq/src/core/recv.rs
+++ b/libzmq/src/core/recv.rs
@@ -198,7 +198,7 @@ impl RecvConfig {
 impl Default for RecvConfig {
     fn default() -> Self {
         Self {
-            recv_high_water_mark: Quantity::Limited(1000),
+            recv_high_water_mark: Quantity::default_high_water_mark(),
             recv_timeout: Period::Infinite,
         }
     }

--- a/libzmq/src/core/send.rs
+++ b/libzmq/src/core/send.rs
@@ -226,7 +226,7 @@ impl SendConfig {
 impl Default for SendConfig {
     fn default() -> Self {
         Self {
-            send_high_water_mark: Quantity::Limited(1000),
+            send_high_water_mark: Quantity::default_high_water_mark(),
             send_timeout: Period::Infinite,
         }
     }

--- a/libzmq/src/socket/client.rs
+++ b/libzmq/src/socket/client.rs
@@ -182,8 +182,10 @@ struct FlatClientConfig {
     connect: Option<Vec<Endpoint>>,
     bind: Option<Vec<Endpoint>>,
     heartbeat: Option<Heartbeat>,
+    #[serde(default = "Quantity::default_high_water_mark")]
     send_high_water_mark: Quantity,
     send_timeout: Period,
+    #[serde(default = "Quantity::default_high_water_mark")]
     recv_high_water_mark: Quantity,
     recv_timeout: Period,
     mechanism: Option<Mechanism>,

--- a/libzmq/src/socket/dish.rs
+++ b/libzmq/src/socket/dish.rs
@@ -395,6 +395,7 @@ impl DishConfig {
 struct FlatDishConfig {
     connect: Option<Vec<Endpoint>>,
     bind: Option<Vec<Endpoint>>,
+    #[serde(default = "Quantity::default_high_water_mark")]
     recv_high_water_mark: Quantity,
     recv_timeout: Period,
     groups: Option<Vec<Group>>,

--- a/libzmq/src/socket/gather.rs
+++ b/libzmq/src/socket/gather.rs
@@ -177,6 +177,7 @@ struct FlatGatherConfig {
     connect: Option<Vec<Endpoint>>,
     bind: Option<Vec<Endpoint>>,
     heartbeat: Option<Heartbeat>,
+    #[serde(default = "Quantity::default_high_water_mark")]
     recv_high_water_mark: Quantity,
     recv_timeout: Period,
     mechanism: Option<Mechanism>,

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -259,6 +259,7 @@ impl RadioConfig {
 struct FlatRadioConfig {
     connect: Option<Vec<Endpoint>>,
     bind: Option<Vec<Endpoint>>,
+    #[serde(default = "Quantity::default_high_water_mark")]
     send_high_water_mark: Quantity,
     send_timeout: Period,
     no_drop: Option<bool>,

--- a/libzmq/src/socket/scatter.rs
+++ b/libzmq/src/socket/scatter.rs
@@ -168,6 +168,7 @@ struct FlatScatterConfig {
     connect: Option<Vec<Endpoint>>,
     bind: Option<Vec<Endpoint>>,
     heartbeat: Option<Heartbeat>,
+    #[serde(default = "Quantity::default_high_water_mark")]
     send_high_water_mark: Quantity,
     send_timeout: Period,
     mechanism: Option<Mechanism>,

--- a/libzmq/src/socket/server.rs
+++ b/libzmq/src/socket/server.rs
@@ -223,8 +223,10 @@ struct FlatServerConfig {
     connect: Option<Vec<Endpoint>>,
     bind: Option<Vec<Endpoint>>,
     heartbeat: Option<Heartbeat>,
+    #[serde(default = "Quantity::default_high_water_mark")]
     send_high_water_mark: Quantity,
     send_timeout: Period,
+    #[serde(default = "Quantity::default_high_water_mark")]
     recv_high_water_mark: Quantity,
     recv_timeout: Period,
     mechanism: Option<Mechanism>,


### PR DESCRIPTION
Since we are mapping our config types to flat structs for
serializing / deserializing purposes, we also need to
use the proper high_water_mark default value in those too.