### PR TITLE
Added {send,recv}_batch_size option

### DIFF
--- a/libzmq/examples/secure_req_rep.yml
+++ b/libzmq/examples/secure_req_rep.yml
@@ -36,10 +36,6 @@ server:
       interval: 1s
       timeout: 3s
       ttl: 3s
-  send_high_water_mark: 10
-  send_timeout: 300ms
-  recv_high_water_mark: 100
-  recv_timeout: 300ms
   mechanism:
     curve_server:
       secret: "iaoRiIVA^VgV:f4a<@{8K{cP62cE:dh=4:oY+^l("

--- a/libzmq/src/core/raw.rs
+++ b/libzmq/src/core/raw.rs
@@ -300,9 +300,9 @@ impl RawSocket {
         &self,
         hwm: i32,
     ) -> Result<(), Error> {
-        if hwm == 0 {
+        if hwm <= 0 {
             return Err(Error::new(ErrorKind::InvalidInput(
-                "high water mark cannot be zero",
+                "high water mark must be greater than zero",
             )));
         }
         setsockopt_scalar(
@@ -310,6 +310,19 @@ impl RawSocket {
             SocketOption::RecvHighWaterMark,
             hwm,
         )
+    }
+
+    pub(crate) fn recv_batch_size(&self) -> Result<i32, Error> {
+        getsockopt_scalar(self.as_mut_ptr(), SocketOption::InBatchSize)
+    }
+
+    pub(crate) fn set_recv_batch_size(&self, size: i32) -> Result<(), Error> {
+        if size <= 0 {
+            return Err(Error::new(ErrorKind::InvalidInput(
+                "batch size must be greater than zero",
+            )));
+        }
+        setsockopt_scalar(self.as_mut_ptr(), SocketOption::InBatchSize, size)
     }
 
     pub(crate) fn recv_timeout(&self) -> Result<Period, Error> {
@@ -338,9 +351,9 @@ impl RawSocket {
         &self,
         hwm: i32,
     ) -> Result<(), Error> {
-        if hwm == 0 {
+        if hwm <= 0 {
             return Err(Error::new(ErrorKind::InvalidInput(
-                "high water mark cannot be zero",
+                "high water mark must be greater than zero",
             )));
         }
         setsockopt_scalar(
@@ -348,6 +361,19 @@ impl RawSocket {
             SocketOption::SendHighWaterMark,
             hwm,
         )
+    }
+
+    pub(crate) fn send_batch_size(&self) -> Result<i32, Error> {
+        getsockopt_scalar(self.as_mut_ptr(), SocketOption::OutBatchSize)
+    }
+
+    pub(crate) fn set_send_batch_size(&self, size: i32) -> Result<(), Error> {
+        if size <= 0 {
+            return Err(Error::new(ErrorKind::InvalidInput(
+                "batch size must be greater than zero",
+            )));
+        }
+        setsockopt_scalar(self.as_mut_ptr(), SocketOption::OutBatchSize, size)
     }
 
     pub(crate) fn send_timeout(&self) -> Result<Period, Error> {

--- a/libzmq/src/core/recv.rs
+++ b/libzmq/src/core/recv.rs
@@ -153,8 +153,57 @@ pub trait RecvMsg: GetRawSocket {
     ///
     /// # Default
     /// 1000
+    ///
+    /// [`InvalidInput`]: ../enum.ErrorKind.html#variant.InvalidInput
     fn set_recv_high_water_mark(&self, hwm: i32) -> Result<(), Error> {
         self.raw_socket().set_recv_high_water_mark(hwm)
+    }
+
+    /// Maximal amount of messages that can be sent in a single
+    /// 'recv' system call.
+    ///
+    /// This can be used to improve throughtput at the expense of
+    /// latency and vice-versa.
+    ///
+    /// # Default value
+    /// 8192
+    ///
+    /// # Example
+    /// ```
+    /// # use failure::Error;
+    /// #
+    /// # fn main() -> Result<(), Error> {
+    /// use libzmq::{prelude::*, *};
+    ///
+    /// let client = ClientBuilder::new().build()?;
+    /// assert_eq!(client.recv_batch_size()?, 8192);
+    ///
+    /// #
+    /// #     Ok(())
+    /// # }
+    /// ```
+    fn recv_batch_size(&self) -> Result<i32, Error> {
+        self.raw_socket().recv_batch_size()
+    }
+
+    /// Sets the maximal amount of messages that can be sent in a single
+    /// 'recv' system call.
+    ///
+    /// This can be used to improve throughtput at the expense of
+    /// latency and vice-versa.
+    ///
+    /// # Usage Contract
+    /// * The batch size cannot be zero.
+    ///
+    /// # Returned Error
+    /// * [`InvalidInput`](on contract violation)
+    ///
+    /// # Default value
+    /// 8192
+    ///
+    /// [`InvalidInput`]: ../enum.ErrorKind.html#variant.InvalidInput
+    fn set_recv_batch_size(&self, size: i32) -> Result<(), Error> {
+        self.raw_socket().set_recv_batch_size(size)
     }
 
     /// The timeout for [`recv`] on the socket.
@@ -187,12 +236,14 @@ pub trait RecvMsg: GetRawSocket {
 pub struct RecvConfig {
     pub(crate) recv_high_water_mark: HighWaterMark,
     pub(crate) recv_timeout: Period,
+    pub(crate) recv_batch_size: BatchSize,
 }
 
 impl RecvConfig {
     pub(crate) fn apply<S: RecvMsg>(&self, socket: &S) -> Result<(), Error> {
         socket.set_recv_high_water_mark(self.recv_high_water_mark.into())?;
         socket.set_recv_timeout(self.recv_timeout)?;
+        socket.set_recv_batch_size(self.recv_batch_size.into())?;
 
         Ok(())
     }
@@ -212,7 +263,15 @@ pub trait ConfigureRecv: GetRecvConfig {
     }
 
     fn set_recv_high_water_mark(&mut self, hwm: i32) {
-        self.recv_config_mut().recv_high_water_mark = hwm.into();
+        self.recv_config_mut().recv_high_water_mark = HighWaterMark(hwm);
+    }
+
+    fn recv_batch_size(&self) -> i32 {
+        self.recv_config().recv_batch_size.into()
+    }
+
+    fn set_recv_batch_size(&mut self, size: i32) {
+        self.recv_config_mut().recv_batch_size = BatchSize(size);
     }
 
     fn recv_timeout(&self) -> Period {
@@ -227,7 +286,12 @@ pub trait ConfigureRecv: GetRecvConfig {
 /// A set of provided methods for the builder of a socket that implements `RecvMsg`.
 pub trait BuildRecv: GetRecvConfig {
     fn recv_high_water_mark(&mut self, hwm: i32) -> &mut Self {
-        self.recv_config_mut().recv_high_water_mark = hwm.into();
+        self.recv_config_mut().recv_high_water_mark = HighWaterMark(hwm);
+        self
+    }
+
+    fn recv_batch_size(&mut self, size: i32) -> &mut Self {
+        self.recv_config_mut().recv_batch_size = BatchSize(size);
         self
     }
 

--- a/libzmq/src/core/sockopt.rs
+++ b/libzmq/src/core/sockopt.rs
@@ -41,6 +41,8 @@ pub(crate) enum SocketOption {
     CurveSecretKey = sys::ZMQ_CURVE_SECRETKEY as isize,
     CurveServer = sys::ZMQ_CURVE_SERVER as isize,
     CurveServerKey = sys::ZMQ_CURVE_SERVERKEY as isize,
+    InBatchSize = sys::ZMQ_IN_BATCH_SIZE as isize,
+    OutBatchSize = sys::ZMQ_OUT_BATCH_SIZE as isize,
 }
 
 impl From<SocketOption> for c_int {
@@ -88,6 +90,8 @@ impl From<SocketOption> for c_int {
             SocketOption::CurveServerKey => {
                 SocketOption::CurveServerKey as c_int
             }
+            SocketOption::InBatchSize => SocketOption::InBatchSize as c_int,
+            SocketOption::OutBatchSize => SocketOption::OutBatchSize as c_int,
         }
     }
 }

--- a/libzmq/src/socket/client.rs
+++ b/libzmq/src/socket/client.rs
@@ -184,8 +184,10 @@ struct FlatClientConfig {
     heartbeat: Option<Heartbeat>,
     send_high_water_mark: HighWaterMark,
     send_timeout: Period,
+    send_batch_size: BatchSize,
     recv_high_water_mark: HighWaterMark,
     recv_timeout: Period,
+    recv_batch_size: BatchSize,
     mechanism: Option<Mechanism>,
 }
 
@@ -202,8 +204,10 @@ impl From<ClientConfig> for FlatClientConfig {
             mechanism: socket_config.mechanism,
             send_high_water_mark: send_config.send_high_water_mark,
             send_timeout: send_config.send_timeout,
+            send_batch_size: send_config.send_batch_size,
             recv_high_water_mark: recv_config.recv_high_water_mark,
             recv_timeout: recv_config.recv_timeout,
+            recv_batch_size: recv_config.recv_batch_size,
         }
     }
 }
@@ -218,10 +222,12 @@ impl From<FlatClientConfig> for ClientConfig {
         let send_config = SendConfig {
             send_high_water_mark: flat.send_high_water_mark,
             send_timeout: flat.send_timeout,
+            send_batch_size: flat.send_batch_size,
         };
         let recv_config = RecvConfig {
             recv_high_water_mark: flat.recv_high_water_mark,
             recv_timeout: flat.recv_timeout,
+            recv_batch_size: flat.recv_batch_size,
         };
         let heartbeat_config = HeartbeatingConfig {
             heartbeat: flat.heartbeat,

--- a/libzmq/src/socket/dish.rs
+++ b/libzmq/src/socket/dish.rs
@@ -397,6 +397,7 @@ struct FlatDishConfig {
     bind: Option<Vec<Endpoint>>,
     recv_high_water_mark: HighWaterMark,
     recv_timeout: Period,
+    recv_batch_size: BatchSize,
     groups: Option<Vec<Group>>,
     mechanism: Option<Mechanism>,
 }
@@ -411,6 +412,7 @@ impl From<DishConfig> for FlatDishConfig {
             mechanism: socket_config.mechanism,
             recv_high_water_mark: recv_config.recv_high_water_mark,
             recv_timeout: recv_config.recv_timeout,
+            recv_batch_size: recv_config.recv_batch_size,
             groups: config.groups,
         }
     }
@@ -426,6 +428,7 @@ impl From<FlatDishConfig> for DishConfig {
         let recv_config = RecvConfig {
             recv_high_water_mark: flat.recv_high_water_mark,
             recv_timeout: flat.recv_timeout,
+            recv_batch_size: flat.recv_batch_size,
         };
         Self {
             socket_config,

--- a/libzmq/src/socket/gather.rs
+++ b/libzmq/src/socket/gather.rs
@@ -179,6 +179,7 @@ struct FlatGatherConfig {
     heartbeat: Option<Heartbeat>,
     recv_high_water_mark: HighWaterMark,
     recv_timeout: Period,
+    recv_batch_size: BatchSize,
     mechanism: Option<Mechanism>,
 }
 
@@ -194,6 +195,7 @@ impl From<GatherConfig> for FlatGatherConfig {
             mechanism: socket_config.mechanism,
             recv_high_water_mark: recv_config.recv_high_water_mark,
             recv_timeout: recv_config.recv_timeout,
+            recv_batch_size: recv_config.recv_batch_size,
         }
     }
 }
@@ -208,6 +210,7 @@ impl From<FlatGatherConfig> for GatherConfig {
         let recv_config = RecvConfig {
             recv_high_water_mark: flat.recv_high_water_mark,
             recv_timeout: flat.recv_timeout,
+            recv_batch_size: flat.recv_batch_size,
         };
         let heartbeat_config = HeartbeatingConfig {
             heartbeat: flat.heartbeat,

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -261,6 +261,7 @@ struct FlatRadioConfig {
     bind: Option<Vec<Endpoint>>,
     send_high_water_mark: HighWaterMark,
     send_timeout: Period,
+    send_batch_size: BatchSize,
     no_drop: Option<bool>,
     mechanism: Option<Mechanism>,
 }
@@ -274,6 +275,7 @@ impl From<RadioConfig> for FlatRadioConfig {
             bind: socket_config.bind,
             send_high_water_mark: send_config.send_high_water_mark,
             send_timeout: send_config.send_timeout,
+            send_batch_size: send_config.send_batch_size,
             no_drop: config.no_drop,
             mechanism: socket_config.mechanism,
         }
@@ -290,6 +292,7 @@ impl From<FlatRadioConfig> for RadioConfig {
         let send_config = SendConfig {
             send_high_water_mark: flat.send_high_water_mark,
             send_timeout: flat.send_timeout,
+            send_batch_size: flat.send_batch_size,
         };
         Self {
             socket_config,

--- a/libzmq/src/socket/scatter.rs
+++ b/libzmq/src/socket/scatter.rs
@@ -170,6 +170,7 @@ struct FlatScatterConfig {
     heartbeat: Option<Heartbeat>,
     send_high_water_mark: HighWaterMark,
     send_timeout: Period,
+    send_batch_size: BatchSize,
     mechanism: Option<Mechanism>,
 }
 
@@ -185,6 +186,7 @@ impl From<ScatterConfig> for FlatScatterConfig {
             mechanism: socket_config.mechanism,
             send_high_water_mark: send_config.send_high_water_mark,
             send_timeout: send_config.send_timeout,
+            send_batch_size: send_config.send_batch_size,
         }
     }
 }
@@ -199,6 +201,7 @@ impl From<FlatScatterConfig> for ScatterConfig {
         let send_config = SendConfig {
             send_high_water_mark: flat.send_high_water_mark,
             send_timeout: flat.send_timeout,
+            send_batch_size: flat.send_batch_size,
         };
         let heartbeat_config = HeartbeatingConfig {
             heartbeat: flat.heartbeat,

--- a/libzmq/src/socket/server.rs
+++ b/libzmq/src/socket/server.rs
@@ -225,8 +225,10 @@ struct FlatServerConfig {
     heartbeat: Option<Heartbeat>,
     send_high_water_mark: HighWaterMark,
     send_timeout: Period,
+    send_batch_size: BatchSize,
     recv_high_water_mark: HighWaterMark,
     recv_timeout: Period,
+    recv_batch_size: BatchSize,
     mechanism: Option<Mechanism>,
 }
 
@@ -243,8 +245,10 @@ impl From<ServerConfig> for FlatServerConfig {
             mechanism: socket_config.mechanism,
             send_high_water_mark: send_config.send_high_water_mark,
             send_timeout: send_config.send_timeout,
+            send_batch_size: send_config.send_batch_size,
             recv_high_water_mark: recv_config.recv_high_water_mark,
             recv_timeout: recv_config.recv_timeout,
+            recv_batch_size: recv_config.recv_batch_size,
         }
     }
 }
@@ -259,10 +263,12 @@ impl From<FlatServerConfig> for ServerConfig {
         let send_config = SendConfig {
             send_high_water_mark: flat.send_high_water_mark,
             send_timeout: flat.send_timeout,
+            send_batch_size: flat.send_batch_size,
         };
         let recv_config = RecvConfig {
             recv_high_water_mark: flat.recv_high_water_mark,
             recv_timeout: flat.recv_timeout,
+            recv_batch_size: flat.recv_batch_size,
         };
         let heartbeat_config = HeartbeatingConfig {
             heartbeat: flat.heartbeat,


### PR DESCRIPTION
Allows for specifying the maximal amount of messages processed in
a single I/O operation, when receiving of sending.