### PR TITLE
Re-added unbind method

### DIFF
--- a/libzmq/src/core/raw.rs
+++ b/libzmq/src/core/raw.rs
@@ -136,6 +136,29 @@ fn disconnect(socket_ptr: *mut c_void, c_string: CString) -> Result<(), Error> {
     }
 }
 
+fn unbind(socket_ptr: *mut c_void, c_string: CString) -> Result<(), Error> {
+    let rc = unsafe { sys::zmq_unbind(socket_ptr, c_string.as_ptr()) };
+
+    if rc == -1 {
+        let errno = unsafe { sys::zmq_errno() };
+        let err = match errno {
+            errno::EINVAL => {
+                panic!("invalid endpoint : {}", c_string.to_string_lossy())
+            }
+            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ENOTSOCK => panic!("invalid socket"),
+            errno::ENOENT => {
+                Error::new(ErrorKind::NotFound("endpoint was not bound to"))
+            }
+            _ => panic!(msg_from_errno(errno)),
+        };
+
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
 /// This socket may or may not be thread safe depending on the `RawSocketType`.
 /// We prevent that it is always thread-safe and let the wrapping types decide.
 #[derive(Debug)]
@@ -209,6 +232,11 @@ impl RawSocket {
     pub(crate) fn disconnect(&self, endpoint: &Endpoint) -> Result<(), Error> {
         let c_string = CString::new(endpoint.to_zmq()).unwrap();
         disconnect(self.as_mut_ptr(), c_string)
+    }
+
+    pub(crate) fn unbind(&self, endpoint: &Endpoint) -> Result<(), Error> {
+        let c_string = CString::new(endpoint.to_zmq()).unwrap();
+        unbind(self.as_mut_ptr(), c_string)
     }
 
     pub(crate) fn ctx(&self) -> &Ctx {


### PR DESCRIPTION
However the is currently no mechanism to check whether the endpoint was connected or bound to first, which is a potential footgun. See https://github.com/zeromq/libzmq/issues/3529.