### PR TITLE
Bumped zeromq-src dependency

### DIFF
--- a/libzmq-sys/Cargo.toml
+++ b/libzmq-sys/Cargo.toml
@@ -30,5 +30,4 @@ version-sync = "0.8"
 [build-dependencies]
 cmake = "0.1"
 bindgen = { version = "0.49.0", optional = true }
-# Use `libzmq` version 4.3.2 which is still a dev preview.
-zeromq-src = "=0.1.6-preview.1"
+zeromq-src = "0.1.7"


### PR DESCRIPTION
This releases libzmq+4.3.2 and also fixes a critical vulnerability
in the CURVE auth mechanism. See CVE-2019-13132.