### PR TITLE
Release libzmq-sys 0.1.6

### DIFF
--- a/libzmq-sys/Cargo.toml
+++ b/libzmq-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzmq-sys"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["jean-airoldie <maxence.caron@protonmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -31,4 +31,4 @@ version-sync = "0.8"
 cmake = "0.1"
 bindgen = { version = "0.49.0", optional = true }
 # Use `libzmq` version 4.3.2 which is still a dev preview.
-zeromq-src = "=0.1.6-preview.1"
+zeromq-src = "0.1.7"

--- a/libzmq-sys/src/lib.rs
+++ b/libzmq-sys/src/lib.rs
@@ -1,6 +1,6 @@
 // Ignore generated code
 #![allow(clippy::all)]
-#![doc(html_root_url = "https://docs.rs/libzmq-sys/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/libzmq-sys/0.1.6")]
 
 //! libzmq-sys - Raw cFFI bindings to [libzmq](https://github.com/zeromq/libzmq).
 

--- a/libzmq/Cargo.toml
+++ b/libzmq/Cargo.toml
@@ -24,7 +24,7 @@ humantime-serde = "0.1"
 serde_with = "1.3.1"
 lazy_static = "1.3.0"
 failure = "0.1"
-libzmq-sys = { path = "../libzmq-sys", version = "0.1.5" }
+libzmq-sys = { path = "../libzmq-sys", version = "0.1.6" }
 bitflags = "1.0"
 hashbrown = "0.2"
 log = "0.4"


### PR DESCRIPTION
This releases libzmq+4.3.2 and also fixes a critical vulnerability
in the CURVE auth mechanism. See CVE-2019-13132.