### PR TITLE
Split `Ctx` into `Ctx` and `CtxHandle`

### DIFF
--- a/libzmq/examples/basic_req_rep.rs
+++ b/libzmq/examples/basic_req_rep.rs
@@ -27,12 +27,12 @@ fn main() -> Result<(), failure::Error> {
     let msg = client.recv_msg()?;
     assert_eq!(msg.to_str(), Ok("pong"));
 
-    // This will cause the server to fail with `CtxTerminated`.
+    // This will cause the server to fail with `CtxInvalid`.
     Ctx::global().shutdown();
 
     // Join with the thread.
     let err = handle.join().unwrap().unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::CtxTerminated);
+    assert_eq!(err.kind(), ErrorKind::CtxInvalid);
 
     Ok(())
 }

--- a/libzmq/examples/reliable_req_rep.rs
+++ b/libzmq/examples/reliable_req_rep.rs
@@ -52,12 +52,12 @@ fn main() -> Result<(), failure::Error> {
     let msg = client.recv_msg()?;
     assert_eq!(msg.to_str(), Ok("pong"));
 
-    // This will cause the server to fail with `CtxTerminated`.
+    // This will cause the server to fail with `CtxInvalid`.
     Ctx::global().shutdown();
 
     // Join with the thread.
     let err = handle.join().unwrap().unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::CtxTerminated);
+    assert_eq!(err.kind(), ErrorKind::CtxInvalid);
 
     Ok(())
 }

--- a/libzmq/examples/secure_req_rep.rs
+++ b/libzmq/examples/secure_req_rep.rs
@@ -67,12 +67,12 @@ fn main() -> Result<(), failure::Error> {
     let msg = client.recv_msg()?;
     assert_eq!(msg.to_str(), Ok("pong"));
 
-    // This will cause the server to fail with `CtxTerminated`.
+    // This will cause the server to fail with `CtxInvalid`.
     Ctx::global().shutdown();
 
     // Join with the thread.
     let err = handle.join().unwrap().unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::CtxTerminated);
+    assert_eq!(err.kind(), ErrorKind::CtxInvalid);
 
     Ok(())
 }

--- a/libzmq/src/auth/server.rs
+++ b/libzmq/src/auth/server.rs
@@ -157,15 +157,11 @@ pub(crate) struct AuthServer {
 }
 
 impl AuthServer {
-    pub(crate) fn with_ctx<C>(ctx: C) -> Result<Self, Error>
-    where
-        C: Into<Ctx>,
-    {
-        let ctx = ctx.into();
-        let mut handler = OldSocket::with_ctx(OldSocketType::Router, &ctx)?;
+    pub(crate) fn with_ctx(handle: CtxHandle) -> Result<Self, Error> {
+        let mut handler = OldSocket::with_ctx(OldSocketType::Router, handle)?;
         handler.bind(&*ZAP_ENDPOINT)?;
 
-        let request = Server::with_ctx(ctx)?;
+        let request = Server::with_ctx(handle)?;
         request.bind(&*COMMAND_ENDPOINT).map_err(Error::cast)?;
 
         Ok(AuthServer {

--- a/libzmq/src/core/mod.rs
+++ b/libzmq/src/core/mod.rs
@@ -212,7 +212,7 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Returned Errors
     /// * [`InvalidInput`] (transport incompatible or not supported)
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     ///
     /// # Example
     /// ```
@@ -234,7 +234,7 @@ pub trait Socket: GetRawSocket {
     /// ```
     /// [`Endpoints`]: ../endpoint/enum.Endpoint.html
     /// [`InvalidInput`]: ../enum.ErrorKind.html#variant.InvalidInput
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     fn connect<I, E>(&self, endpoints: I) -> Result<(), Error<usize>>
     where
         I: IntoIterator<Item = E>,
@@ -273,7 +273,7 @@ pub trait Socket: GetRawSocket {
     /// * [`InvalidInput`] (transport incompatible or not supported)
     /// * [`AddrInUse`] (addr already in use)
     /// * [`AddrNotAvailable`] (addr not local)
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     ///
     /// # Example
     /// ```
@@ -296,7 +296,7 @@ pub trait Socket: GetRawSocket {
     /// [`InvalidInput`]: ../enum.ErrorKind.html#variant.InvalidInput
     /// [`AddrInUse`]: ../enum.ErrorKind.html#variant.AddrInUse
     /// [`AddrNotAvailable`]: ../enum.ErrorKind.html#variant.AddrNotAvailable
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     fn bind<I, E>(&self, endpoints: I) -> Result<(), Error<usize>>
     where
         I: IntoIterator<Item = E>,
@@ -334,10 +334,10 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Returned Errors
     /// * [`NotFound`] (endpoint was not connected to)
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     ///
     /// [`Endpoints`]: ../endpoint/enum.Endpoint.html
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`NotFound`]: ../enum.ErrorKind.html#variant.NotFound
     fn disconnect<I, E>(&self, endpoints: I) -> Result<(), Error<usize>>
     where
@@ -374,10 +374,10 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Returned Errors
     /// * [`NotFound`] (endpoint was not bound to)
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     ///
     /// [`Endpoints`]: ../endpoint/enum.Endpoint.html
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`NotFound`]: ../enum.ErrorKind.html#variant.NotFound
     fn unbind<I, E>(&self, endpoints: I) -> Result<(), Error<usize>>
     where

--- a/libzmq/src/core/recv.rs
+++ b/libzmq/src/core/recv.rs
@@ -28,7 +28,7 @@ fn recv(
             errno::EFSM => {
                 panic!("operation cannot be completed in current socket state")
             }
-            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ETERM => Error::new(ErrorKind::CtxInvalid),
             errno::ENOTSOCK => panic!("invalid socket"),
             errno::EINTR => Error::new(ErrorKind::Interrupted),
             errno::EFAULT => panic!("invalid message"),
@@ -55,11 +55,11 @@ pub trait RecvMsg: GetRawSocket {
     ///
     /// ## Possible Error Variants
     /// * [`WouldBlock`] (if `recv_timeout` expires)
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`Interrupted`]
     ///
     /// [`WouldBlock`]: ../enum.ErrorKind.html#variant.WouldBlock
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`Interrupted`]: ../enum.ErrorKind.html#variant.Interrupted
     fn recv(&self, msg: &mut Msg) -> Result<(), Error> {
         recv(self.raw_socket().as_mut_ptr(), msg, false)
@@ -76,11 +76,11 @@ pub trait RecvMsg: GetRawSocket {
     ///
     /// ## Possible Error Variants
     /// * [`WouldBlock`]
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`Interrupted`]
     ///
     /// [`WouldBlock`]: ../enum.ErrorKind.html#variant.WouldBlock
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`Interrupted`]: ../enum.ErrorKind.html#variant.Interrupted
     fn try_recv(&self, msg: &mut Msg) -> Result<(), Error> {
         recv(self.raw_socket().as_mut_ptr(), msg, true)

--- a/libzmq/src/core/send.rs
+++ b/libzmq/src/core/send.rs
@@ -31,7 +31,7 @@ fn send(
             errno::EFSM => {
                 panic!("operation cannot be completed in current socket state")
             }
-            errno::ETERM => Error::with_content(ErrorKind::CtxTerminated, msg),
+            errno::ETERM => Error::with_content(ErrorKind::CtxInvalid, msg),
             errno::ENOTSOCK => panic!("invalid socket"),
             errno::EINTR => Error::with_content(ErrorKind::Interrupted, msg),
             errno::EFAULT => panic!("invalid message"),
@@ -67,13 +67,13 @@ pub trait SendMsg: GetRawSocket {
     ///
     /// ## Possible Error Variants
     /// * [`WouldBlock`] (if `send_timeout` expires)
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`Interrupted`]
     /// * [`HostUnreachable`] (only for [`Server`] socket)
     ///
     /// [`zmq_msg_send`]: http://api.zeromq.org/master:zmq-msg-send
     /// [`WouldBlock`]: ../enum.ErrorKind.html#variant.WouldBlock
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`Interrupted`]: ../enum.ErrorKind.html#variant.Interrupted
     /// [`HostUnreachable`]: ../enum.ErrorKind.html#variant.HostUnreachable
     /// [`Server`]: struct.Server.html
@@ -100,13 +100,13 @@ pub trait SendMsg: GetRawSocket {
     ///
     /// ## Possible Error Variants
     /// * [`WouldBlock`]
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`Interrupted`]
     /// * [`HostUnreachable`] (only for [`Server`] socket)
     ///
     /// [`zmq_msg_send`]: http://api.zeromq.org/master:zmq-msg-send
     /// [`WouldBlock`]: ../enum.ErrorKind.html#variant.WouldBlock
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`Interrupted`]: ../enum.ErrorKind.html#variant.Interrupted
     /// [`HostUnreachable`]: ../enum.ErrorKind.html#variant.HostUnreachable
     /// [`Server`]: struct.Server.html

--- a/libzmq/src/core/sockopt.rs
+++ b/libzmq/src/core/sockopt.rs
@@ -110,7 +110,7 @@ fn getsockopt(
         let errno = unsafe { sys::zmq_errno() };
         let err = match errno {
             errno::EINVAL => panic!("invalid option"),
-            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ETERM => Error::new(ErrorKind::CtxInvalid),
             errno::ENOTSOCK => panic!("invalid socket"),
             errno::EINTR => Error::new(ErrorKind::Interrupted),
             _ => panic!(msg_from_errno(errno)),
@@ -216,7 +216,7 @@ fn setsockopt(
         let errno = unsafe { sys::zmq_errno() };
         let err = match errno {
             errno::EINVAL => panic!("invalid option"),
-            errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+            errno::ETERM => Error::new(ErrorKind::CtxInvalid),
             errno::ENOTSOCK => panic!("invalid socket"),
             errno::EINTR => Error::new(ErrorKind::Interrupted),
             _ => panic!(msg_from_errno(errno)),

--- a/libzmq/src/lib.rs
+++ b/libzmq/src/lib.rs
@@ -18,7 +18,7 @@ mod socket;
 mod utils;
 
 pub use crate::core::{Heartbeat, Period};
-pub use ctx::{Ctx, CtxBuilder};
+pub use ctx::{Ctx, CtxBuilder, CtxHandle};
 pub use endpoint::{
     EpgmAddr, InprocAddr, PgmAddr, TcpAddr, UdpAddr, INPROC_MAX_SIZE,
 };

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -748,7 +748,7 @@ impl Poller {
             let errno = unsafe { sys::zmq_errno() };
             let err = match errno {
                 errno::EINVAL => panic!("invalid poller"),
-                errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+                errno::ETERM => Error::new(ErrorKind::CtxInvalid),
                 errno::EINTR => Error::new(ErrorKind::Interrupted),
                 errno::EAGAIN => Error::new(ErrorKind::WouldBlock),
                 _ => panic!(msg_from_errno(errno)),
@@ -767,11 +767,11 @@ impl Poller {
     ///
     /// # Returned Errors
     /// * [`WouldBlock`]
-    /// * [`CtxTerminated`] (`Ctx` of a polled socket was terminated)
+    /// * [`CtxInvalid`] (`Ctx` of a polled socket was terminated)
     /// * [`Interrupted`]
     ///
     /// [`Interrupted`]: ../enum.ErrorKind.html#variant.Interrupted
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`WouldBlock`]: ../enum.ErrorKind.html#variant.Interrupted
     pub fn try_poll(&mut self, events: &mut Events) -> Result<(), Error> {
         self.wait(events, 0)
@@ -786,11 +786,11 @@ impl Poller {
     ///
     /// # Returned Errors
     /// * [`WouldBlock`] (timeout expired)
-    /// * [`CtxTerminated`] (`Ctx` of a polled socket was terminated)
+    /// * [`CtxInvalid`] (`Ctx` of a polled socket was terminated)
     /// * [`Interrupted`]
     ///
     /// [`Interrupted`]: ../enum.ErrorKind.html#variant.Interrupted
-    /// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
     /// [`WouldBlock`]: ../enum.ErrorKind.html#variant.WouldBlock
     pub fn poll(
         &mut self,

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -99,10 +99,10 @@ impl Radio {
     /// Create a `Radio` socket from the [`global context`]
     ///
     /// # Returned Error Variants
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`SocketLimit`]
     ///
-    /// [`CtxTerminated`]: enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: enum.ErrorKind.html#variant.CtxInvalid
     /// [`SocketLimit`]: enum.ErrorKind.html#variant.SocketLimit
     /// [`global context`]: struct.Ctx.html#method.global
     pub fn new() -> Result<Self, Error> {
@@ -111,25 +111,24 @@ impl Radio {
         Ok(Self { inner })
     }
 
-    /// Create a `Radio` socket from a specific context.
+    /// Create a `Radio` socket associated with a specific context
+    /// from a `CtxHandle`.
     ///
     /// # Returned Error Variants
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`SocketLimit`]
     ///
-    /// [`CtxTerminated`]: enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: enum.ErrorKind.html#variant.CtxInvalid
     /// [`SocketLimit`]: enum.ErrorKind.html#variant.SocketLimit
-    pub fn with_ctx<C>(ctx: C) -> Result<Self, Error>
-    where
-        C: Into<Ctx>,
-    {
-        let inner = Arc::new(RawSocket::with_ctx(RawSocketType::Radio, ctx)?);
+    pub fn with_ctx(handle: CtxHandle) -> Result<Self, Error> {
+        let inner =
+            Arc::new(RawSocket::with_ctx(RawSocketType::Radio, handle)?);
 
         Ok(Self { inner })
     }
 
     /// Returns a reference to the context of the socket.
-    pub fn ctx(&self) -> &crate::Ctx {
+    pub fn ctx(&self) -> CtxHandle {
         self.inner.ctx()
     }
 
@@ -221,11 +220,8 @@ impl RadioConfig {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx<C>(&self, ctx: C) -> Result<Radio, Error<usize>>
-    where
-        C: Into<Ctx>,
-    {
-        let radio = Radio::with_ctx(ctx).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Radio, Error<usize>> {
+        let radio = Radio::with_ctx(handle).map_err(Error::cast)?;
         self.apply(&radio)?;
 
         Ok(radio)
@@ -345,11 +341,8 @@ impl RadioBuilder {
         self.inner.build()
     }
 
-    pub fn with_ctx<C>(&self, ctx: C) -> Result<Radio, Error<usize>>
-    where
-        C: Into<Ctx>,
-    {
-        self.inner.with_ctx(ctx)
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Radio, Error<usize>> {
+        self.inner.with_ctx(handle)
     }
 }
 

--- a/libzmq/src/socket/server.rs
+++ b/libzmq/src/socket/server.rs
@@ -88,10 +88,10 @@ impl Server {
     /// Create a `Server` socket from the [`global context`]
     ///
     /// # Returned Error Variants
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`SocketLimit`]
     ///
-    /// [`CtxTerminated`]: enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: enum.ErrorKind.html#variant.CtxInvalid
     /// [`SocketLimit`]: enum.ErrorKind.html#variant.SocketLimit
     /// [`global context`]: ctx/struct.Ctx.html#method.global
     pub fn new() -> Result<Self, Error> {
@@ -100,25 +100,24 @@ impl Server {
         Ok(Self { inner })
     }
 
-    /// Create a `Server` socket from a specific context.
+    /// Create a `Server` socket associated with a specific context
+    /// from a `CtxHandle`.
     ///
     /// # Returned Error Variants
-    /// * [`CtxTerminated`]
+    /// * [`CtxInvalid`]
     /// * [`SocketLimit`]
     ///
-    /// [`CtxTerminated`]: enum.ErrorKind.html#variant.CtxTerminated
+    /// [`CtxInvalid`]: enum.ErrorKind.html#variant.CtxInvalid
     /// [`SocketLimit`]: enum.ErrorKind.html#variant.SocketLimit
-    pub fn with_ctx<C>(ctx: C) -> Result<Server, Error>
-    where
-        C: Into<Ctx>,
-    {
-        let inner = Arc::new(RawSocket::with_ctx(RawSocketType::Server, ctx)?);
+    pub fn with_ctx(handle: CtxHandle) -> Result<Server, Error> {
+        let inner =
+            Arc::new(RawSocket::with_ctx(RawSocketType::Server, handle)?);
 
         Ok(Self { inner })
     }
 
     /// Returns a reference to the context of the socket.
-    pub fn ctx(&self) -> &crate::Ctx {
+    pub fn ctx(&self) -> CtxHandle {
         self.inner.ctx()
     }
 
@@ -195,11 +194,8 @@ impl ServerConfig {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx<C>(&self, ctx: C) -> Result<Server, Error<usize>>
-    where
-        C: Into<Ctx>,
-    {
-        let server = Server::with_ctx(ctx.into()).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Server, Error<usize>> {
+        let server = Server::with_ctx(handle).map_err(Error::cast)?;
         self.apply(&server)?;
 
         Ok(server)
@@ -341,11 +337,8 @@ impl ServerBuilder {
         self.inner.build()
     }
 
-    pub fn with_ctx<C>(&self, ctx: C) -> Result<Server, Error<usize>>
-    where
-        C: Into<Ctx>,
-    {
-        self.inner.with_ctx(ctx)
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Server, Error<usize>> {
+        self.inner.with_ctx(handle)
     }
 }
 

--- a/libzmq/src/utils.rs
+++ b/libzmq/src/utils.rs
@@ -44,7 +44,7 @@ pub fn version() -> (i32, i32, i32) {
 /// backend.
 ///
 /// # Returned Errors
-/// * [`CtxTerminated`]
+/// * [`CtxInvalid`]
 ///
 /// # Example
 /// ```
@@ -89,7 +89,7 @@ pub fn version() -> (i32, i32, i32) {
 /// # }
 /// ```
 ///
-/// [`CtxTerminated`]: ../enum.ErrorKind.html#variant.CtxTerminated
+/// [`CtxInvalid`]: ../enum.ErrorKind.html#variant.CtxInvalid
 pub fn proxy<F, B>(frontend: F, backend: B) -> Result<(), Error>
 where
     F: GetRawSocket,
@@ -105,7 +105,7 @@ where
 
     let errno = unsafe { sys::zmq_errno() };
     let err = match errno {
-        errno::ETERM => Error::new(ErrorKind::CtxTerminated),
+        errno::ETERM => Error::new(ErrorKind::CtxInvalid),
         _ => panic!(msg_from_errno(errno)),
     };
 


### PR DESCRIPTION
The `Ctx` is slit into two parts, the actual `Ctx` and `CtxHandle`
which are meant to be used by sockets. The principal distinction is
that the `Ctx` implements Drop (which terminates the context) while
`CtxHandle` does not. This is convenient because this allows the
lifetime of a `Ctx` to be more obvious (the context is dropped
when `Ctx` is dropped. This also allows `CtxHandle` which implements
copy, which makes usage more ergonomic.