### PR TITLE
Remove IntoIterator pattern from socket methods

### DIFF
--- a/libzmq/benches/curve.rs
+++ b/libzmq/benches/curve.rs
@@ -38,7 +38,7 @@ pub(crate) fn bench(c: &mut Criterion) {
                 .build()
                 .unwrap();
 
-            let bound = producer.last_endpoint().unwrap().unwrap();
+            let bound = producer.last_endpoint().unwrap();
             let consumer = ClientBuilder::new()
                 .connect(bound)
                 .recv_hwm(HWM)
@@ -73,7 +73,7 @@ pub(crate) fn bench(c: &mut Criterion) {
                 .build()
                 .unwrap();
 
-            let bound = producer.last_endpoint().unwrap().unwrap();
+            let bound = producer.last_endpoint().unwrap();
 
             let creds = CurveClientCreds::new(server_cert.public());
 

--- a/libzmq/benches/socket.rs
+++ b/libzmq/benches/socket.rs
@@ -39,7 +39,7 @@ pub(crate) fn bench(c: &mut Criterion) {
                 .build()
                 .unwrap();
 
-            let bound = producer.last_endpoint().unwrap().unwrap();
+            let bound = producer.last_endpoint().unwrap();
             let consumer = ClientBuilder::new()
                 .connect(bound)
                 .recv_hwm(HWM)
@@ -67,7 +67,7 @@ pub(crate) fn bench(c: &mut Criterion) {
                 .build()
                 .unwrap();
 
-            let bound = producer.last_endpoint().unwrap().unwrap();
+            let bound = producer.last_endpoint().unwrap();
             let consumer = DishBuilder::new()
                 .connect(bound)
                 .recv_hwm(HWM)
@@ -93,7 +93,7 @@ pub(crate) fn bench(c: &mut Criterion) {
                 .build()
                 .unwrap();
 
-            let bound = producer.last_endpoint().unwrap().unwrap();
+            let bound = producer.last_endpoint().unwrap();
             let consumer = GatherBuilder::new()
                 .connect(bound)
                 .recv_hwm(HWM)

--- a/libzmq/examples/reliable_req_rep.rs
+++ b/libzmq/examples/reliable_req_rep.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), failure::Error> {
         .build()?;
 
     // Retrieve the assigned port.
-    let bound = server.last_endpoint()?.unwrap();
+    let bound = server.last_endpoint()?;
 
     // Spawn the server thread. In a real application, this
     // would be on another node.

--- a/libzmq/src/auth/client.rs
+++ b/libzmq/src/auth/client.rs
@@ -519,7 +519,7 @@ mod test {
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
         let _ = AuthBuilder::new().blacklist(ip).with_ctx(handle).unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
         let client = ClientBuilder::new()
             .connect(bound)
             .with_ctx(handle)
@@ -546,7 +546,7 @@ mod test {
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
         let _ = AuthBuilder::new().whitelist(ip).with_ctx(handle).unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
         let client = ClientBuilder::new()
             .connect(bound)
             .with_ctx(handle)
@@ -565,7 +565,7 @@ mod test {
             .build()
             .unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
         let client = Client::new().unwrap();
 
         client.connect(bound).unwrap();
@@ -585,7 +585,7 @@ mod test {
             .build()
             .unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
 
         let client = Client::new().unwrap();
 
@@ -618,7 +618,7 @@ mod test {
             .with_ctx(handle)
             .unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
 
         let client = ClientBuilder::new()
             .connect(bound)
@@ -661,7 +661,7 @@ mod test {
             .with_ctx(handle)
             .unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
 
         let client = ClientBuilder::new()
             .mechanism(client_creds)
@@ -690,7 +690,7 @@ mod test {
             .build()
             .unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
 
         let client = ClientBuilder::new()
             .mechanism(client_creds)
@@ -723,7 +723,7 @@ mod test {
             .with_ctx(handle)
             .unwrap();
 
-        let bound = server.last_endpoint().unwrap().unwrap();
+        let bound = server.last_endpoint().unwrap();
 
         let client = Client::with_ctx(handle).unwrap();
 

--- a/libzmq/src/core/heartbeat.rs
+++ b/libzmq/src/core/heartbeat.rs
@@ -180,10 +180,8 @@ impl HeartbeatingConfig {
     pub(crate) fn apply<S: Heartbeating>(
         &self,
         socket: &S,
-    ) -> Result<(), Error<usize>> {
-        socket
-            .set_heartbeat(self.heartbeat.clone())
-            .map_err(Error::cast)
+    ) -> Result<(), Error> {
+        socket.set_heartbeat(self.heartbeat.clone())
     }
 }
 

--- a/libzmq/src/socket/client.rs
+++ b/libzmq/src/socket/client.rs
@@ -152,21 +152,21 @@ impl ClientConfig {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Client, Error<usize>> {
+    pub fn build(&self) -> Result<Client, Error> {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Client, Error<usize>> {
-        let client = Client::with_ctx(handle).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Client, Error> {
+        let client = Client::with_ctx(handle)?;
         self.apply(&client)?;
 
         Ok(client)
     }
 
-    pub fn apply(&self, client: &Client) -> Result<(), Error<usize>> {
-        self.send_config.apply(client).map_err(Error::cast)?;
-        self.recv_config.apply(client).map_err(Error::cast)?;
-        self.heartbeat_config.apply(client).map_err(Error::cast)?;
+    pub fn apply(&self, client: &Client) -> Result<(), Error> {
+        self.send_config.apply(client)?;
+        self.recv_config.apply(client)?;
+        self.heartbeat_config.apply(client)?;
         self.socket_config.apply(client)?;
 
         Ok(())
@@ -292,11 +292,11 @@ impl ClientBuilder {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Client, Error<usize>> {
+    pub fn build(&self) -> Result<Client, Error> {
         self.inner.build()
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Client, Error<usize>> {
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Client, Error> {
         self.inner.with_ctx(handle)
     }
 }

--- a/libzmq/src/socket/dish.rs
+++ b/libzmq/src/socket/dish.rs
@@ -88,7 +88,7 @@ fn leave(socket_mut_ptr: *mut c_void, group: &GroupSlice) -> Result<(), Error> {
 ///     .bind(addr)
 ///     .build()?;
 ///
-/// let bound = radio.last_endpoint().unwrap();
+/// let bound = radio.last_endpoint()?;
 /// let a: Group = "group a".try_into()?;
 ///
 /// let dish = DishBuilder::new()
@@ -228,14 +228,13 @@ impl Dish {
     /// # fn main() -> Result<(), Error> {
     /// use libzmq::{prelude::*, Dish, Group};
     ///
-    /// let first: Group = "first group".try_into()?;
-    /// let second: Group = "second group".try_into()?;
+    /// let first: Group = "group name".try_into()?;
     ///
     /// let dish = Dish::new()?;
     /// assert!(dish.joined().is_empty());
     ///
-    /// dish.join(&[first, second])?;
-    /// assert_eq!(dish.joined().len(), 2);
+    /// dish.join(first)?;
+    /// assert_eq!(dish.joined().len(), 1);
     /// #
     /// #     Ok(())
     /// # }
@@ -278,7 +277,7 @@ impl Dish {
     /// [`InvalidCtx`]: enum.ErrorKind.html#variant.InvalidCtx
     /// [`Interrupted`]: enum.ErrorKind.html#variant.Interrupted
     /// [`InvalidInput`]: enum.ErrorKind.html#variant.InvalidInput
-    pub fn leave<I, G>(&self, group: G) -> Result<(), Error>
+    pub fn leave<G>(&self, group: G) -> Result<(), Error>
     where
         G: AsRef<GroupSlice>,
     {

--- a/libzmq/src/socket/gather.rs
+++ b/libzmq/src/socket/gather.rs
@@ -149,19 +149,19 @@ impl GatherConfig {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Gather, Error<usize>> {
+    pub fn build(&self) -> Result<Gather, Error> {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Gather, Error<usize>> {
-        let gather = Gather::with_ctx(handle).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Gather, Error> {
+        let gather = Gather::with_ctx(handle)?;
         self.apply(&gather)?;
 
         Ok(gather)
     }
 
-    pub fn apply(&self, gather: &Gather) -> Result<(), Error<usize>> {
-        self.recv_config.apply(gather).map_err(Error::cast)?;
+    pub fn apply(&self, gather: &Gather) -> Result<(), Error> {
+        self.recv_config.apply(gather)?;
         self.socket_config.apply(gather)?;
 
         Ok(())
@@ -264,11 +264,11 @@ impl GatherBuilder {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Gather, Error<usize>> {
+    pub fn build(&self) -> Result<Gather, Error> {
         self.inner.build()
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Gather, Error<usize>> {
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Gather, Error> {
         self.inner.with_ctx(handle)
     }
 }

--- a/libzmq/src/socket/mod.rs
+++ b/libzmq/src/socket/mod.rs
@@ -70,7 +70,7 @@ pub enum ConfigType {
 }
 
 impl ConfigType {
-    pub fn build(&self) -> Result<SocketType, Error<usize>> {
+    pub fn build(&self) -> Result<SocketType, Error> {
         match self {
             ConfigType::Client(config) => {
                 let client = config.build()?;

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 ///     .bind(addr)
 ///     .build()?;
 ///
-/// let bound = radio.last_endpoint().unwrap();
+/// let bound = radio.last_endpoint()?;
 /// let a: Group = "A".try_into()?;
 /// let b: Group = "B".try_into()?;
 ///

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -216,12 +216,12 @@ impl RadioConfig {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Radio, Error<usize>> {
+    pub fn build(&self) -> Result<Radio, Error> {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Radio, Error<usize>> {
-        let radio = Radio::with_ctx(handle).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Radio, Error> {
+        let radio = Radio::with_ctx(handle)?;
         self.apply(&radio)?;
 
         Ok(radio)
@@ -237,11 +237,11 @@ impl RadioConfig {
         self.no_drop = Some(cond);
     }
 
-    pub fn apply(&self, radio: &Radio) -> Result<(), Error<usize>> {
+    pub fn apply(&self, radio: &Radio) -> Result<(), Error> {
         if let Some(enabled) = self.no_drop {
-            radio.set_no_drop(enabled).map_err(Error::cast)?;
+            radio.set_no_drop(enabled)?;
         }
-        self.send_config.apply(radio).map_err(Error::cast)?;
+        self.send_config.apply(radio)?;
         self.socket_config.apply(radio)?;
 
         Ok(())
@@ -337,11 +337,11 @@ impl RadioBuilder {
         self
     }
 
-    pub fn build(&self) -> Result<Radio, Error<usize>> {
+    pub fn build(&self) -> Result<Radio, Error> {
         self.inner.build()
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Radio, Error<usize>> {
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Radio, Error> {
         self.inner.with_ctx(handle)
     }
 }

--- a/libzmq/src/socket/scatter.rs
+++ b/libzmq/src/socket/scatter.rs
@@ -140,19 +140,19 @@ impl ScatterConfig {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Scatter, Error<usize>> {
+    pub fn build(&self) -> Result<Scatter, Error> {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Scatter, Error<usize>> {
-        let scatter = Scatter::with_ctx(handle).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Scatter, Error> {
+        let scatter = Scatter::with_ctx(handle)?;
         self.apply(&scatter)?;
 
         Ok(scatter)
     }
 
-    pub fn apply(&self, scatter: &Scatter) -> Result<(), Error<usize>> {
-        self.send_config.apply(scatter).map_err(Error::cast)?;
+    pub fn apply(&self, scatter: &Scatter) -> Result<(), Error> {
+        self.send_config.apply(scatter)?;
         self.socket_config.apply(scatter)?;
 
         Ok(())
@@ -255,11 +255,11 @@ impl ScatterBuilder {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Scatter, Error<usize>> {
+    pub fn build(&self) -> Result<Scatter, Error> {
         self.inner.build()
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Scatter, Error<usize>> {
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Scatter, Error> {
         self.inner.with_ctx(handle)
     }
 }

--- a/libzmq/src/socket/server.rs
+++ b/libzmq/src/socket/server.rs
@@ -190,21 +190,21 @@ impl ServerConfig {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Server, Error<usize>> {
+    pub fn build(&self) -> Result<Server, Error> {
         self.with_ctx(Ctx::global())
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Server, Error<usize>> {
-        let server = Server::with_ctx(handle).map_err(Error::cast)?;
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Server, Error> {
+        let server = Server::with_ctx(handle)?;
         self.apply(&server)?;
 
         Ok(server)
     }
 
-    pub fn apply(&self, server: &Server) -> Result<(), Error<usize>> {
-        self.send_config.apply(server).map_err(Error::cast)?;
-        self.recv_config.apply(server).map_err(Error::cast)?;
-        self.heartbeat_config.apply(server).map_err(Error::cast)?;
+    pub fn apply(&self, server: &Server) -> Result<(), Error> {
+        self.send_config.apply(server)?;
+        self.recv_config.apply(server)?;
+        self.heartbeat_config.apply(server)?;
         self.socket_config.apply(server)?;
 
         Ok(())
@@ -333,11 +333,11 @@ impl ServerBuilder {
         Self::default()
     }
 
-    pub fn build(&self) -> Result<Server, Error<usize>> {
+    pub fn build(&self) -> Result<Server, Error> {
         self.inner.build()
     }
 
-    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Server, Error<usize>> {
+    pub fn with_ctx(&self, handle: CtxHandle) -> Result<Server, Error> {
         self.inner.with_ctx(handle)
     }
 }


### PR DESCRIPTION
This will greatly simplify the error handling. Closes #119