### PR TITLE
Fixed UB in setsockopt_option_scalar

### DIFF
--- a/libzmq/src/auth/curve.rs
+++ b/libzmq/src/auth/curve.rs
@@ -840,7 +840,7 @@ mod tests {
 
     quickcheck! {
         fn codec_quickcheck(input: Vec<u8>) -> bool {
-            let mut input = input.clone();
+            let mut input = input;
             input.extend_from_slice(&input.clone());
             input.extend_from_slice(&input.clone());
 

--- a/libzmq/src/core/sockopt.rs
+++ b/libzmq/src/core/sockopt.rs
@@ -16,6 +16,7 @@ use std::{
 const MAX_OPTION_SIZE: size_t = 255;
 
 #[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
 pub(crate) enum SocketOption {
     Backlog = sys::ZMQ_BACKLOG as isize,
     ConnectTimeout = sys::ZMQ_CONNECT_TIMEOUT as isize,
@@ -262,11 +263,16 @@ where
 {
     let size = mem::size_of::<T>() as size_t;
 
-    let value_ptr = match maybe {
-        Some(value) => &value as *const T as *const c_void,
-        None => &none_value as *const T as *const c_void,
-    };
-    setsockopt(mut_sock_ptr, option, value_ptr, size)
+    match maybe {
+        Some(value) => {
+            let value_ptr = &value as *const T as *const c_void;
+            setsockopt(mut_sock_ptr, option, value_ptr, size)
+        }
+        None => {
+            let value_ptr = &none_value as *const T as *const c_void;
+            setsockopt(mut_sock_ptr, option, value_ptr, size)
+        }
+    }
 }
 
 pub(crate) fn setsockopt_bytes(

--- a/libzmq/src/ctx.rs
+++ b/libzmq/src/ctx.rs
@@ -17,6 +17,7 @@ lazy_static! {
 }
 
 #[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
 enum CtxOption {
     IOThreads,
     MaxSockets,

--- a/libzmq/src/old.rs
+++ b/libzmq/src/old.rs
@@ -54,6 +54,7 @@ fn recv(mut_sock_ptr: *mut c_void, msg: &mut Msg) -> Result<(), Error> {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) enum OldSocketType {
     Router,
     Dealer,

--- a/libzmq/src/socket/gather.rs
+++ b/libzmq/src/socket/gather.rs
@@ -314,6 +314,8 @@ mod test {
     use super::*;
     use crate::*;
 
+    use std::time::Duration;
+
     #[test]
     fn test_ser_de() {
         let config = GatherConfig::new();
@@ -321,6 +323,14 @@ mod test {
         let ron = serde_yaml::to_string(&config).unwrap();
         let de: GatherConfig = serde_yaml::from_str(&ron).unwrap();
         assert_eq!(config, de);
+    }
+
+    #[test]
+    fn test_issue_125() {
+        let gather = Gather::new().unwrap();
+        gather
+            .set_recv_timeout(Some(Duration::from_secs(3)))
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
* Also whitelisted some clippy dead_code warnings.

Closes #125.