### PR TITLE
Fix compilation on 32bit machines

### DIFF
--- a/libzmq/src/auth/server.rs
+++ b/libzmq/src/auth/server.rs
@@ -68,6 +68,18 @@ impl TryFrom<c_long> for StatusCode {
     }
 }
 
+#[cfg(target_pointer_width = "32")]
+impl<'a> TryFrom<&'a [u8]> for StatusCode {
+    type Error = StatusCodeParseError;
+    fn try_from(a: &'a [u8]) -> Result<Self, Self::Error> {
+        let mut bytes: [u8; 4] = Default::default();
+        bytes.copy_from_slice(a);
+        let code = c_long::from_ne_bytes(bytes);
+        Self::try_from(code)
+    }
+}
+
+#[cfg(not(target_pointer_width = "32"))]
 impl<'a> TryFrom<&'a [u8]> for StatusCode {
     type Error = StatusCodeParseError;
     fn try_from(a: &'a [u8]) -> Result<Self, Self::Error> {

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -735,12 +735,22 @@ impl Poller {
         for _i in 0..self.count {
             events.inner.push(sys::zmq_poller_event_t::default());
         }
+        #[cfg(not(target_pointer_width = "32"))]
         let rc = unsafe {
             sys::zmq_poller_wait_all(
                 self.poller,
                 events.inner.as_mut_ptr(),
                 events.inner.len() as i32,
-                timeout.into(),
+                timeout,
+            )
+        };
+        #[cfg(target_pointer_width = "32")]
+        let rc = unsafe {
+            sys::zmq_poller_wait_all(
+                self.poller,
+                events.inner.as_mut_ptr(),
+                events.inner.len() as i32,
+                timeout as i32,
             )
         };
 

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -16,7 +16,7 @@ use sys::errno;
 use bitflags::bitflags;
 
 use std::os::{
-    raw::{c_short, c_void},
+    raw::{c_short, c_void, c_long},
     unix::io::{AsRawFd, RawFd},
 };
 
@@ -735,22 +735,12 @@ impl Poller {
         for _i in 0..self.count {
             events.inner.push(sys::zmq_poller_event_t::default());
         }
-        #[cfg(not(target_pointer_width = "32"))]
         let rc = unsafe {
             sys::zmq_poller_wait_all(
                 self.poller,
                 events.inner.as_mut_ptr(),
                 events.inner.len() as i32,
-                timeout,
-            )
-        };
-        #[cfg(target_pointer_width = "32")]
-        let rc = unsafe {
-            sys::zmq_poller_wait_all(
-                self.poller,
-                events.inner.as_mut_ptr(),
-                events.inner.len() as i32,
-                timeout as i32,
+                timeout as c_long,
             )
         };
 

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -740,7 +740,7 @@ impl Poller {
                 self.poller,
                 events.inner.as_mut_ptr(),
                 events.inner.len() as i32,
-                timeout,
+                timeout.into(),
             )
         };
 

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -16,7 +16,7 @@ use sys::errno;
 use bitflags::bitflags;
 
 use std::os::{
-    raw::{c_short, c_void, c_long},
+    raw::{c_long, c_short, c_void},
     unix::io::{AsRawFd, RawFd},
 };
 


### PR DESCRIPTION
Fix compilation issues on machines where c_long is 32 bits instead of 64.  

Tested on Raspbian Buster (32bit) and Ubuntu 16.04 (64bit)