### PR TITLE
Fix Travis test failing

### DIFF
--- a/libzmq/src/core/mod.rs
+++ b/libzmq/src/core/mod.rs
@@ -703,7 +703,7 @@ mod test {
         // this means that is only one outstanding message.
         client.disconnect(bound).unwrap();
         // Let the client some time to disconnect.
-        thread::sleep(Duration::from_millis(50));
+        thread::sleep(Duration::from_millis(200));
 
         // The client's incoming message queue was discarded.
         client.try_recv(&mut msg).unwrap_err();


### PR DESCRIPTION
I've noticed that one of the tests was failing on Travis.
After some investigation it turned out to be because the test wasn't waiting for disconnection for long enough.

I know that just increasing the sleep on this test is not an ideal solution. But I think that it's a decent workaround for now