### PR TITLE
Replace failure with thiserror

### DIFF
--- a/libzmq-sys/src/bindings.rs
+++ b/libzmq-sys/src/bindings.rs
@@ -210,6 +210,9 @@ pub const ZMQ_CURRENT_EVENT_VERSION: u32 = 1;
 pub const ZMQ_CURRENT_EVENT_VERSION_DRAFT: u32 = 2;
 pub const ZMQ_EVENT_ALL_V1: u32 = 65535;
 pub const ZMQ_EVENT_ALL_V2: u32 = 131071;
+pub type __uint8_t = ::std::os::raw::c_uchar;
+pub type __uint32_t = ::std::os::raw::c_uint;
+pub type __uint64_t = ::std::os::raw::c_ulong;
 extern "C" {
     pub fn zmq_errno() -> ::std::os::raw::c_int;
 }

--- a/libzmq-sys/src/errno.rs
+++ b/libzmq-sys/src/errno.rs
@@ -33,7 +33,7 @@ pub const EPROTO: i32 = errno::EOPNOTSUPP;
 pub const EPROTONOSUPPORT: i32 = errno::EPROTONOSUPPORT;
 
 #[cfg(not(target_os = "windows"))]
-pub const ENOTSUP: i32 = (ZMQ_HAUSNUMERO + 1);
+pub const ENOTSUP: i32 = ZMQ_HAUSNUMERO + 1;
 #[cfg(target_os = "windows")]
 pub const ENOTSUP: i32 = errno::ENOTSUP;
 
@@ -42,7 +42,7 @@ pub const ENETDOWN: i32 = errno::ENETDOWN;
 pub const EADDRNOTAVAIL: i32 = errno::EADDRNOTAVAIL;
 
 // native zmq error codes
-pub const EFSM: i32 = (ZMQ_HAUSNUMERO + 51);
-pub const ENOCOMPATPROTO: i32 = (ZMQ_HAUSNUMERO + 52);
-pub const ETERM: i32 = (ZMQ_HAUSNUMERO + 53);
-pub const EMTHREAD: i32 = (ZMQ_HAUSNUMERO + 54);
+pub const EFSM: i32 = ZMQ_HAUSNUMERO + 51;
+pub const ENOCOMPATPROTO: i32 = ZMQ_HAUSNUMERO + 52;
+pub const ETERM: i32 = ZMQ_HAUSNUMERO + 53;
+pub const EMTHREAD: i32 = ZMQ_HAUSNUMERO + 54;

--- a/libzmq/Cargo.toml
+++ b/libzmq/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 humantime-serde = "1.0"
 serde_with = "1.3.1"
 lazy_static = "1.3.0"
-failure = "0.1"
+thiserror = "1"
 libzmq-sys = { path = "../libzmq-sys", version = "0.1.7" }
 bitflags = "1.0"
 log = "0.4"
@@ -35,6 +35,7 @@ bincode = "1.1"
 byteorder = "1.3.1"
 
 [dev-dependencies]
+anyhow = "1"
 rand = "0.7"
 rand_isaac = "0.2"
 rand_core = "0.5"

--- a/libzmq/examples/basic_req_rep.rs
+++ b/libzmq/examples/basic_req_rep.rs
@@ -2,7 +2,7 @@ use libzmq::{prelude::*, *};
 
 use std::thread;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), anyhow::Error> {
     let addr: InprocAddr = InprocAddr::new_unique();
 
     let server = ServerBuilder::new().bind(&addr).build()?;

--- a/libzmq/examples/reliable_req_rep.rs
+++ b/libzmq/examples/reliable_req_rep.rs
@@ -2,7 +2,7 @@ use libzmq::{prelude::*, *};
 
 use std::{thread, time::Duration};
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), anyhow::Error> {
     // We use a system assigned port here.
     let addr: TcpAddr = "127.0.0.1:*".try_into()?;
     let duration = Duration::from_millis(300);

--- a/libzmq/examples/secure_req_rep.rs
+++ b/libzmq/examples/secure_req_rep.rs
@@ -25,7 +25,7 @@ fn read_file(name: &Path) -> std::io::Result<Vec<u8>> {
     Ok(buf)
 }
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), anyhow::Error> {
     let path = PathBuf::from("examples").join(CONFIG_FILE);
 
     let config: Config =

--- a/libzmq/src/auth/client.rs
+++ b/libzmq/src/auth/client.rs
@@ -41,9 +41,7 @@ fn into_ipv6(ip: IpAddr) -> Ipv6Addr {
 /// # Example
 ///
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// #[cfg(feature = "curve")] {
 ///     use libzmq::{prelude::*, auth::*, *};
 ///     use std::{time::Duration};

--- a/libzmq/src/auth/curve.rs
+++ b/libzmq/src/auth/curve.rs
@@ -3,9 +3,9 @@ use super::Mechanism;
 use crate::prelude::TryFrom;
 
 use libzmq_sys as sys;
+use thiserror::Error;
 
 use byteorder::{BigEndian, ByteOrder};
-use failure::Fail;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use std::{ffi::CString, fmt, option, os::raw::c_char};
@@ -36,13 +36,14 @@ static OCTETS: [u8; 96] = [
 const CURVE_CURVE_KEY_SIZE: usize = 40;
 
 /// A error when encoding or decoding a `CurveKey`.
-#[derive(Debug, Fail, Eq, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
 pub enum CurveError {
-    #[fail(display = "input string must have len of 40 char")]
+    #[error("input string must have len of 40 char")]
     InvalidSize,
-    #[fail(
-        display = "input string contains invalid byte 0x{:2X} at offset {}",
-        byte, pos
+    #[error(
+        "input string contains invalid byte 0x{:2X} at offset {}",
+        byte,
+        pos
     )]
     InvalidByte { pos: usize, byte: u8 },
 }

--- a/libzmq/src/auth/mechanism.rs
+++ b/libzmq/src/auth/mechanism.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::{prelude::TryFrom, *};
 
-use failure::Fail;
 use serde::{Deserialize, Serialize};
 
 use std::option;
@@ -258,8 +257,8 @@ pub(crate) enum MechanismName {
     Curve,
 }
 
-#[derive(Debug, Fail)]
-#[fail(display = "unsupported mechanism")]
+#[derive(Debug, Error)]
+#[error("unsupported mechanism")]
 pub(crate) struct InvalidMechanismName;
 
 impl<'a> TryFrom<&'a str> for MechanismName {

--- a/libzmq/src/auth/mod.rs
+++ b/libzmq/src/auth/mod.rs
@@ -18,11 +18,10 @@ pub use client::{AuthBuilder, AuthClient};
 pub use curve::*;
 pub use server::{StatusCode, StatusCodeParseError};
 
-use super::*;
 use crate::prelude::TryFrom;
 
-use failure::Fail;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use std::option;
 
@@ -160,8 +159,8 @@ pub(crate) enum MechanismName {
     Curve,
 }
 
-#[derive(Debug, Fail)]
-#[fail(display = "unsupported mechanism")]
+#[derive(Debug, Error)]
+#[error("unsupported mechanism")]
 pub(crate) struct InvalidMechanismName;
 
 impl<'a> TryFrom<&'a str> for MechanismName {

--- a/libzmq/src/auth/server.rs
+++ b/libzmq/src/auth/server.rs
@@ -1,9 +1,9 @@
 use super::{client::*, *};
 use crate::{old::*, poll::*, prelude::*, socket::*, *};
 
-use failure::Fail;
 use lazy_static::lazy_static;
 use log::info;
+use thiserror::Error;
 
 use libc::c_long;
 
@@ -46,8 +46,8 @@ impl fmt::Display for StatusCode {
     }
 }
 
-#[derive(Debug, Fail)]
-#[fail(display = "unable to parse status code")]
+#[derive(Debug, Error)]
+#[error("unable to parse status code")]
 #[doc(hidden)]
 pub struct StatusCodeParseError(());
 

--- a/libzmq/src/core/heartbeat.rs
+++ b/libzmq/src/core/heartbeat.rs
@@ -133,9 +133,7 @@ impl<'a> From<&'a Heartbeat> for Heartbeat {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, Client, Heartbeat, auth::*};
 /// use std::time::Duration;
 ///

--- a/libzmq/src/core/mod.rs
+++ b/libzmq/src/core/mod.rs
@@ -217,9 +217,7 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Client, TcpAddr};
     /// use std::convert::TryInto;
     ///
@@ -260,9 +258,7 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Server, TcpAddr};
     /// use std::convert::TryInto;
     ///
@@ -354,9 +350,7 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Server, TcpAddr, addr::Endpoint, ErrorKind};
     ///
     /// // We create a tcp addr with an unspecified port.
@@ -401,9 +395,7 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Server, auth::Mechanism};
     ///
     /// let server = Server::new()?;
@@ -427,9 +419,7 @@ pub trait Socket: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// #[cfg(feature = "curve")] {
     ///     use libzmq::{prelude::*, Client, auth::*};
     ///

--- a/libzmq/src/core/recv.rs
+++ b/libzmq/src/core/recv.rs
@@ -122,9 +122,7 @@ pub trait RecvMsg: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, *};
     ///
     /// let client = ClientBuilder::new().build()?;

--- a/libzmq/src/core/send.rs
+++ b/libzmq/src/core/send.rs
@@ -129,9 +129,7 @@ pub trait SendMsg: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, *};
     ///
     /// let client = ClientBuilder::new().build()?;
@@ -186,9 +184,7 @@ pub trait SendMsg: GetRawSocket {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Client, ErrorKind};
     /// use std::time::Duration;
     ///

--- a/libzmq/src/ctx.rs
+++ b/libzmq/src/ctx.rs
@@ -177,9 +177,7 @@ impl CtxBuilder {
     ///
     /// # Usage Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::*;
     ///
     /// let ctx = CtxBuilder::new()
@@ -203,9 +201,7 @@ impl CtxBuilder {
     ///
     /// # Usage Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::*;
     ///
     /// let global = Ctx::global();
@@ -251,9 +247,7 @@ impl CtxBuilder {
 /// `CtxHandle` will be invalidated. All calls involving an invalidated
 /// `CtxHandle` will return a `InvalidCtx` error.
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{Ctx, Dish, ErrorKind};
 ///
 /// // We create a `CtxHandle` from a new context. Since we drop
@@ -381,9 +375,7 @@ impl Ctx {
     /// context aliased by the handle.
     ///
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{Ctx, Server};
     ///
     /// let ctx = Ctx::new();
@@ -406,9 +398,7 @@ impl Ctx {
     ///
     /// # Usage Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{Ctx, Client};
     ///
     /// // A socket created via `new` will use the global context via
@@ -440,9 +430,7 @@ impl Ctx {
     ///
     /// # Usage Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::Ctx;
     ///
     /// let ctx = Ctx::new();
@@ -472,9 +460,7 @@ impl Ctx {
     ///
     /// # Usage Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::Ctx;
     ///
     /// let ctx = Ctx::new();

--- a/libzmq/src/endpoint.rs
+++ b/libzmq/src/endpoint.rs
@@ -1,6 +1,6 @@
 use crate::prelude::TryFrom;
-use failure::Fail;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
 use uuid::Uuid;
 
 use std::{
@@ -78,8 +78,8 @@ where
 /// An error that occurs when an address cannot be parsed.
 ///
 /// The error contains a message detailling the source of the error.
-#[derive(Debug, Fail)]
-#[fail(display = "cannot parse address : {}", msg)]
+#[derive(Debug, Error)]
+#[error("cannot parse address : {}", msg)]
 pub struct AddrParseError {
     msg: &'static str,
 }
@@ -152,9 +152,7 @@ macro_rules! tryfrom_fromstr {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, addr::Hostname};
 ///
 /// // This is a network interface.
@@ -239,9 +237,7 @@ impl<'a> TryFrom<&'a str> for Hostname {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, addr::Port};
 ///
 /// let port: Port = "*".try_into()?;
@@ -310,9 +306,7 @@ serde_display_tryfrom!(Port);
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, addr::Interface};
 ///
 /// let interface: Interface = "0.0.0.0".try_into()?;
@@ -361,9 +355,7 @@ serde_display_tryfrom!(Interface);
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, addr::SocketAddr};
 ///
 /// let host: SocketAddr = "127.0.0.1:3000".try_into()?;
@@ -455,9 +447,7 @@ impl<'a> From<&'a SocketAddr> for SocketAddr {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, addr::SrcAddr};
 ///
 /// // Specify an IPv4 addr with a unspecified port.
@@ -527,9 +517,7 @@ impl<'a> From<&'a SrcAddr> for SrcAddr {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, TcpAddr};
 ///
 /// // Connecting using a IPv4 address and bind to `eth0` interface.
@@ -647,9 +635,7 @@ impl<'a> From<&'a TcpAddr> for Endpoint {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, UdpAddr};
 ///
 /// // Multicast - UDP port 5555 on a Multicast address
@@ -670,9 +656,7 @@ pub struct UdpAddr {
 impl UdpAddr {
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::TryInto, UdpAddr, addr::SocketAddr};
     ///
     /// let host: SocketAddr = "localhost:5555".try_into()?;
@@ -694,9 +678,7 @@ impl UdpAddr {
 
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::TryInto, UdpAddr, addr::{SrcAddr, SocketAddr}};
     ///
     /// let host: SocketAddr = "localhost:5555".try_into()?;
@@ -801,9 +783,7 @@ impl<'a> From<&'a UdpAddr> for Endpoint {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, PgmAddr};
 ///
 /// // Connecting to the multicast address 239.192.1.1, port 5555,
@@ -921,9 +901,7 @@ impl<'a> From<&'a PgmAddr> for Endpoint {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, EpgmAddr};
 ///
 /// // Connecting to the multicast address 239.192.1.1, port 5555,
@@ -1048,9 +1026,7 @@ impl<'a> From<&'a EpgmAddr> for Endpoint {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, InprocAddr};
 ///
 /// // Can be any arbitrary string.
@@ -1095,9 +1071,7 @@ impl InprocAddr {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, InprocAddr, ServerBuilder};
     ///
     /// let addr = InprocAddr::new_unique();
@@ -1212,9 +1186,7 @@ impl<'a> From<&'a InprocAddr> for Endpoint {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, TcpAddr, addr::Endpoint};
 ///
 /// // IPv4 addr with TCP transport.

--- a/libzmq/src/error.rs
+++ b/libzmq/src/error.rs
@@ -40,9 +40,8 @@ use std::{convert::Infallible, ffi, fmt, io, str};
 /// ```
 ///
 /// [`ErrorKind`]: enum.ErrorKind.html
-#[derive(Debug)]
 pub struct Error<T = ()> {
-    inner: ErrorKind,
+    kind: ErrorKind,
     content: Option<T>,
 }
 
@@ -52,7 +51,7 @@ impl<T> Error<T> {
     /// The `content` field will be `None`.
     pub(crate) fn new(kind: ErrorKind) -> Self {
         Self {
-            inner: kind,
+            kind,
             content: None,
         }
     }
@@ -60,14 +59,14 @@ impl<T> Error<T> {
     /// Creates a new `Error` from an `ErrorKind` and some content.
     pub(crate) fn with_content(kind: ErrorKind, content: T) -> Self {
         Self {
-            inner: kind,
+            kind,
             content: Some(content),
         }
     }
 
     /// Returns the kind of error.
     pub fn kind(&self) -> ErrorKind {
-        self.inner
+        self.kind
     }
 
     #[deprecated(since = "0.2.1", note = "please use `get` instead")]
@@ -95,23 +94,29 @@ impl<T> Error<T> {
     ///
     /// This is not implemented as `Into<Error<I>>` to be explicit since
     /// information is lost in the conversion.
-    pub fn cast<I: fmt::Debug>(self) -> Error<I> {
+    pub fn cast<I>(self) -> Error<I> {
         Error {
-            inner: self.inner,
+            kind: self.kind,
             content: None,
         }
     }
 }
 
-impl<T: fmt::Debug> std::error::Error for Error<T> {
+impl<T> std::error::Error for Error<T> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.inner.source()
+        self.kind.source()
+    }
+}
+
+impl<T> fmt::Debug for Error<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Error").field("kind", &self.kind).finish()
     }
 }
 
 impl<T> fmt::Display for Error<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
+        fmt::Display::fmt(&self.kind, f)
     }
 }
 

--- a/libzmq/src/group.rs
+++ b/libzmq/src/group.rs
@@ -2,8 +2,8 @@
 
 use crate::prelude::TryFrom;
 
-use failure::Fail;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
 
 use std::{
     borrow::{Borrow, Cow, ToOwned},
@@ -19,8 +19,8 @@ pub const MAX_GROUP_SIZE: usize = 15;
 /// This error occurs from a string that exceeds [`MAX_GROUP_SIZE`] char.
 ///
 /// [`MAX_GROUP_SIZE`]: constant.MAX_GROUP_SIZE.html
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Fail, Hash)]
-#[fail(display = "unable to parse group: {}", msg)]
+#[derive(Debug, Error, Copy, Clone, PartialEq, Eq, Hash)]
+#[error("unable to parse group: {}", msg)]
 pub struct GroupParseError {
     msg: &'static str,
 }
@@ -150,9 +150,7 @@ impl<'a> IntoIterator for &'a GroupSlice {
 ///
 /// # Example
 /// ```
-/// #
-/// # use failure::Error;
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::TryInto, Group};
 ///
 /// let string = "abc".to_owned();

--- a/libzmq/src/lib.rs
+++ b/libzmq/src/lib.rs
@@ -2,8 +2,6 @@
 
 //! *libzmq* - A strict subset of ØMQ with a high level API.
 
-pub use failure;
-
 #[macro_use]
 mod core;
 pub mod auth;

--- a/libzmq/src/msg.rs
+++ b/libzmq/src/msg.rs
@@ -21,9 +21,7 @@ use std::{
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 ///
 /// let addr: TcpAddr = "127.0.0.1:*".try_into()?;
@@ -133,9 +131,7 @@ impl Msg {
     /// Return the message content as a `str` slice if it is valid UTF-8.
     ///
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::Msg;
     ///
     /// let text = "blzit";
@@ -241,9 +237,7 @@ impl Msg {
     /// Set the group property on the message.
     ///
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::TryInto, Msg, Group};
     ///
     /// let a: Group = "A".try_into()?;

--- a/libzmq/src/poll.rs
+++ b/libzmq/src/poll.rs
@@ -103,9 +103,7 @@ impl From<PollId> for usize {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{Server, poll::*};
 /// use std::net::TcpListener;
 ///
@@ -375,9 +373,7 @@ impl IntoIterator for Events {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *, poll::*};
 ///
 /// // We initialize our sockets and connect them to each other.
@@ -454,9 +450,7 @@ impl Poller {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{Server, poll::*, ErrorKind};
     ///
     /// let server = Server::new()?;
@@ -571,9 +565,7 @@ impl Poller {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{Server, poll::*, ErrorKind};
     ///
     /// let server = Server::new()?;

--- a/libzmq/src/socket/client.rs
+++ b/libzmq/src/socket/client.rs
@@ -33,9 +33,7 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 ///
 /// // Use a system assigned port.

--- a/libzmq/src/socket/dish.rs
+++ b/libzmq/src/socket/dish.rs
@@ -76,9 +76,7 @@ fn leave(socket_mut_ptr: *mut c_void, group: &GroupSlice) -> Result<(), Error> {
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 /// use std::{thread, time::Duration};
 ///
@@ -190,9 +188,7 @@ impl Dish {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Dish, Group};
     ///
     /// let group: Group = "some group".try_into()?;
@@ -223,9 +219,7 @@ impl Dish {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Dish, Group};
     ///
     /// let first: Group = "group name".try_into()?;
@@ -255,9 +249,7 @@ impl Dish {
     ///
     /// # Example
     /// ```
-    /// # use failure::Error;
-    /// #
-    /// # fn main() -> Result<(), Error> {
+    /// # fn main() -> Result<(), anyhow::Error> {
     /// use libzmq::{prelude::*, Dish, Group};
     ///
     /// let group: Group = "some group".to_owned().try_into()?;

--- a/libzmq/src/socket/gather.rs
+++ b/libzmq/src/socket/gather.rs
@@ -20,9 +20,7 @@ use std::{str, sync::Arc};
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 ///
 /// let addr_a = InprocAddr::new_unique();

--- a/libzmq/src/socket/radio.rs
+++ b/libzmq/src/socket/radio.rs
@@ -28,9 +28,7 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 /// use std::{thread, time::Duration};
 ///

--- a/libzmq/src/socket/scatter.rs
+++ b/libzmq/src/socket/scatter.rs
@@ -20,9 +20,7 @@ use std::{str, sync::Arc};
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 /// use std::time::Duration;
 ///

--- a/libzmq/src/socket/server.rs
+++ b/libzmq/src/socket/server.rs
@@ -34,9 +34,7 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```
-/// # use failure::Error;
-/// #
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 ///
 /// let addr: TcpAddr = "127.0.0.1:*".try_into()?;

--- a/libzmq/src/utils.rs
+++ b/libzmq/src/utils.rs
@@ -48,9 +48,7 @@ pub fn version() -> (i32, i32, i32) {
 ///
 /// # Example
 /// ```
-/// #
-/// # use failure::Error;
-/// # fn main() -> Result<(), Error> {
+/// # fn main() -> Result<(), anyhow::Error> {
 /// use libzmq::{prelude::*, *};
 /// use std::thread;
 ///


### PR DESCRIPTION
`failure` seems to be [deprecated](https://boats.gitlab.io/blog/post/failure-to-fehler/) and there are some compelling reasons to use `thiserror` instead:
- Better interoperability with other error wrapping solutions since `thiserror` doesn't introduce any custom traits
- It simply derives `std::error::Error` which means compatibility isn't broken if it's replaced down the road
- Better suited for libraries since it doesn't affect the public API and works well with [`anyhow`](https://docs.rs/anyhow/~1/anyhow/)

I would have opened an issue to discuss this, but I was already using the forked version so decided to just submit a PR.